### PR TITLE
Query file path command line arg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.3.0", features = ["derive"] }
 once_cell = "1.17.1"
 regex = "1.8.2"
 tree-sitter = "0.20.10"

--- a/src/bin/tree-sitter-grep.rs
+++ b/src/bin/tree-sitter-grep.rs
@@ -1,5 +1,7 @@
-use tree_sitter_grep::run;
+use clap::Parser;
+use tree_sitter_grep::{run, Args};
 
 pub fn main() {
-    run();
+    let args = Args::parse();
+    run(args);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+use clap::Parser;
+use std::fs;
+use std::path::PathBuf;
 use walkdir::{DirEntry, WalkDir};
 
 mod macros;
@@ -5,14 +8,14 @@ mod treesitter;
 
 use treesitter::{get_query, get_results};
 
-pub fn run() {
-    let query_source = r#"
-        (field_declaration
-          type: (type_identifier) @type
-          (#eq? @type "String")
-        )
-    "#;
-    let query = get_query(query_source);
+#[derive(Parser)]
+pub struct Args {
+    pub path_to_query_file: PathBuf,
+}
+
+pub fn run(args: Args) {
+    let query_source = fs::read_to_string(&args.path_to_query_file).unwrap();
+    let query = get_query(&query_source);
     enumerate_project_files()
         .flat_map(|project_file_dir_entry| get_results(&query, project_file_dir_entry.path(), 0))
         .for_each(|result| {


### PR DESCRIPTION
In this PR:
- accept path to query file as command-line arg

To test:
If you put a file named eg `string-struct-fields.scm` in the project root directory with contents:
```
(field_declaration
  type: (type_identifier) @type
  (#eq? @type "String")
)
```
and then run `cargo run ./string-struct-fields.scm` you should see a single result printed out. Running as just `cargo run` should show you an error message about proper usage