### PR TITLE
Parallelize with rayon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.3.0", features = ["derive"] }
 once_cell = "1.17.1"
+rayon = "1.7.0"
 regex = "1.8.2"
 tree-sitter = "0.20.10"
 tree-sitter-rust = "0.20.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use rayon::prelude::*;
 use std::fs;
 use std::path::PathBuf;
 use walkdir::{DirEntry, WalkDir};
@@ -17,13 +18,14 @@ pub fn run(args: Args) {
     let query_source = fs::read_to_string(&args.path_to_query_file).unwrap();
     let query = get_query(&query_source);
     enumerate_project_files()
+        .par_iter()
         .flat_map(|project_file_dir_entry| get_results(&query, project_file_dir_entry.path(), 0))
         .for_each(|result| {
             println!("{}", result.format());
         });
 }
 
-fn enumerate_project_files() -> impl Iterator<Item = DirEntry> {
+fn enumerate_project_files() -> Vec<DirEntry> {
     WalkDir::new(".")
         .into_iter()
         .filter_map(|entry| entry.ok())
@@ -35,4 +37,5 @@ fn enumerate_project_files() -> impl Iterator<Item = DirEntry> {
             let extension = extension.unwrap();
             "rs" == extension
         })
+        .collect()
 }


### PR DESCRIPTION
In this PR:
- parallelize the tree-sitter query execution via `rayon`

To test:
Behavior should still be the same and faster