### PR TITLE
Use ignore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.3.0", features = ["derive"] }
+ignore = "0.4.20"
 once_cell = "1.17.1"
 rayon = "1.7.0"
 regex = "1.8.2"
 tree-sitter = "0.20.10"
 tree-sitter-rust = "0.20.3"
-walkdir = "2.3.3"
 
 [lib]
 name = "tree_sitter_grep"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
+use ignore::{types::TypesBuilder, DirEntry, WalkBuilder};
 use rayon::prelude::*;
 use std::fs;
 use std::path::PathBuf;
-use walkdir::{DirEntry, WalkDir};
 
 mod macros;
 mod treesitter;
@@ -26,7 +26,15 @@ pub fn run(args: Args) {
 }
 
 fn enumerate_project_files() -> Vec<DirEntry> {
-    WalkDir::new(".")
+    WalkBuilder::new(".")
+        .types(
+            TypesBuilder::new()
+                .add_defaults()
+                .select("rust")
+                .build()
+                .unwrap(),
+        )
+        .build()
         .into_iter()
         .filter_map(|entry| entry.ok())
         .filter(|entry| {


### PR DESCRIPTION
In this PR:
- use the higher-level `ignore` crate instead of `walkdir`

To test:
Behavior should still be basically the same (I guess it should be filtering things out based on eg `.gitignore` now)