### PR TITLE
Capture name argument

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,23 @@ use treesitter::{get_query, get_results};
 #[derive(Parser)]
 pub struct Args {
     pub path_to_query_file: PathBuf,
+    #[arg(short, long = "capture")]
+    pub capture_name: Option<String>,
 }
 
 pub fn run(args: Args) {
     let query_source = fs::read_to_string(&args.path_to_query_file).unwrap();
     let query = get_query(&query_source);
+    let capture_index = args.capture_name.as_ref().map_or(0, |capture_name| {
+        query
+            .capture_index_for_name(capture_name)
+            .expect(&format!("Unknown capture name: `{}`", capture_name))
+    });
     enumerate_project_files()
         .par_iter()
-        .flat_map(|project_file_dir_entry| get_results(&query, project_file_dir_entry.path(), 0))
+        .flat_map(|project_file_dir_entry| {
+            get_results(&query, project_file_dir_entry.path(), capture_index)
+        })
         .for_each(|result| {
             println!("{}", result.format());
         });


### PR DESCRIPTION
In this PR:
- add optional command-line argument for specifying which query capture to show results for (still defaulting to capture index 0 if unspecified)

To test:
If you have a file named eg `string-struct-fields.scm` in the project root with contents:
```
(field_declaration_list
  (field_declaration
    type: (type_identifier) @type
    (#eq? @type "String")
  )
) @declaration_list
```
then if you do `cargo run ./string-struct-fields.scm` or `cargo run -- --capture type ./string-struct-fields.scm` or `cargo run -- -c type ./string-struct-fields.scm` you should see the same result as previously
If you do `cargo run -- --capture declaration_list ./string-struct-fields.scm` you should instead see a result corresponding to the beginning of the enclosing struct fields declaration list