### PR TITLE
Multiple languages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rayon = "1.7.0"
 regex = "1.8.2"
 tree-sitter = "0.20.10"
 tree-sitter-rust = "0.20.3"
+tree-sitter-typescript = "0.20.2"
 
 [lib]
 name = "tree_sitter_grep"

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,0 +1,54 @@
+use clap::ValueEnum;
+use tree_sitter::Language;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+pub enum SupportedLanguageName {
+    Rust,
+    Typescript,
+}
+
+impl SupportedLanguageName {
+    pub fn get_language(self) -> Box<dyn SupportedLanguage> {
+        match self {
+            Self::Rust => Box::new(get_rust_language()),
+            Self::Typescript => Box::new(get_typescript_language()),
+        }
+    }
+}
+
+pub trait SupportedLanguage {
+    fn language(&self) -> Language;
+    fn name_for_ignore_select(&self) -> &'static str;
+}
+
+pub struct SupportedLanguageRust;
+
+impl SupportedLanguage for SupportedLanguageRust {
+    fn language(&self) -> Language {
+        tree_sitter_rust::language()
+    }
+
+    fn name_for_ignore_select(&self) -> &'static str {
+        "rust"
+    }
+}
+
+pub fn get_rust_language() -> SupportedLanguageRust {
+    SupportedLanguageRust
+}
+
+pub struct SupportedLanguageTypescript;
+
+impl SupportedLanguage for SupportedLanguageTypescript {
+    fn language(&self) -> Language {
+        tree_sitter_typescript::language_tsx()
+    }
+
+    fn name_for_ignore_select(&self) -> &'static str {
+        "ts"
+    }
+}
+
+pub fn get_typescript_language() -> SupportedLanguageTypescript {
+    SupportedLanguageTypescript
+}

--- a/src/treesitter/mod.rs
+++ b/src/treesitter/mod.rs
@@ -4,20 +4,16 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use tree_sitter::{Language, Parser, Point, Query, QueryCursor};
 
-pub fn get_rust_language() -> Language {
-    tree_sitter_rust::language()
-}
-
-pub fn get_parser() -> Parser {
+pub fn get_parser(language: Language) -> Parser {
     let mut parser = Parser::new();
     parser
-        .set_language(get_rust_language())
-        .expect("Error loading Rust grammar");
+        .set_language(language)
+        .expect("Error loading grammar");
     parser
 }
 
-pub fn get_query(source: &str) -> Query {
-    Query::new(get_rust_language(), source).unwrap()
+pub fn get_query(source: &str, language: Language) -> Query {
+    Query::new(language, source).unwrap()
 }
 
 pub struct Result {
@@ -44,11 +40,16 @@ fn format_path(path: &Path) -> String {
         .into_owned()
 }
 
-pub fn get_results(query: &Query, file_path: impl AsRef<Path>, capture_index: u32) -> Vec<Result> {
+pub fn get_results(
+    query: &Query,
+    file_path: impl AsRef<Path>,
+    capture_index: u32,
+    language: Language,
+) -> Vec<Result> {
     let mut query_cursor = QueryCursor::new();
     let file_path = file_path.as_ref();
     let file_text = fs::read_to_string(file_path).unwrap();
-    let tree = get_parser().parse(&file_text, None).unwrap();
+    let tree = get_parser(language).parse(&file_text, None).unwrap();
     query_cursor
         .matches(query, tree.root_node(), file_text.as_bytes())
         .flat_map(|match_| {


### PR DESCRIPTION
In this PR:
- add support for targeting Rust vs Typescript source files/queries

To test:
Existing behavior should still work except you should have to add an explicit `-l rust` or `--language rust` command-line argument
If you add eg a file named `tmp.ts` with contents `interface Foo {}` in the project root directory and then run `cargo run -- -l typescript -q "(interface_declaration) @interface_declaration"` you should see a result for that interface declaration in that source file