### PR TITLE
Use grep crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.3.0", features = ["derive"] }
+grep = "0.2.12"
 ignore = "0.4.20"
 once_cell = "1.17.1"
 rayon = "1.7.0"


### PR DESCRIPTION
This is an initial (extremely hacky attempt) at using ripgrep's full infrastructure via it's `grep` crate (which wraps a few other crates). It has a bug right now where it always prints out matches as the first lines of the file the match is in, eg:

```
cargo run -- --language rust --query-source "(field_declaration_list (field_declaration type: (type_identifier) @type))"
   Compiling tree-sitter-grep v0.1.0 (/home/peter/dev/personal/tree-sitter-grep)
    Finished dev [unoptimized + debuginfo] target(s) in 1.61s
     Running `target/debug/tree-sitter-grep --language rust --query-source '(field_declaration_list (field_declaration type: (type_identifier) @type))'`
./src/lib.rs:1:use clap::Parser;
./src/lib.rs:2:use grep::matcher::Match;
```

Assuming that's fixable, using all these crates seems potentially pretty great, even despite the weird mismatch between the `grep` crates expected regex-style "matchers".