### PR TITLE
Parallelize enumerate project files -> query matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,5 @@ name = "tree-sitter-grep"
 [workspace]
 members = ["tree_sitter_grep_filter_before_line_number"]
 
-[profile.release]
-debug = true
+# [profile.release]
+# debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ grep = "0.2.12"
 ignore = "0.4.20"
 libc = "0.2.144"
 libloading = "0.8.0"
+num_cpus = "1.15.0"
 once_cell = "1.17.1"
-rayon = "1.7.0"
 regex = "1.8.2"
+threadpool = "1.8.1"
 tree-sitter = "0.20.10"
 tree-sitter-rust = "0.20.3"
 tree-sitter-typescript = "0.20.2"
@@ -26,3 +27,6 @@ name = "tree-sitter-grep"
 
 [workspace]
 members = ["tree_sitter_grep_filter_before_line_number"]
+
+[profile.release]
+debug = true


### PR DESCRIPTION
In this PR:
- instead of "blocking" on `.collect()`'ing all enumerated project files (via `ignore`) into a `Vec` and _then_ proceeding into the (parallelized) query-matching phase, parallelize the enumerating of project files and start "flowing" those through into query-matching as they are enumerated

I did this because it was seeming like there was a noticeable initial "pause" before any results started showing up and I assumed that was the "enumerating project files" phase, which made me think that it would probably be a significant improvement to overall runtime to not block on that. Indeed here is a basic timing graph from before this branch:
<img width="1784" alt="Screen Shot 2023-05-30 at 12 21 48 PM" src="https://github.com/helixbass/tree-sitter-grep/assets/440230/fdaeef5a-72b3-478f-b562-51960c5af251">
And after:
<img width="1742" alt="Screen Shot 2023-05-30 at 12 22 13 PM" src="https://github.com/helixbass/tree-sitter-grep/assets/440230/d6c51326-8b64-4c44-bea4-b7c2b665434c">

In terms of roughly-measured (via `time`) overall runtime, against the Typescript compiler in Rust codebase it looks like it went from ~460-480ms to ~280-300ms so maybe a 35-40% speedup?

Based on `filter-plugin-c-ffi`