### PR TITLE
Vimgrep mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.3.0", features = ["derive"] }
-# grep = "0.2.12"
-# grep = { path = "../ripgrep/crates/grep" }
 grep = { git = "https://github.com/helixbass/ripgrep", rev = "b83cc3c" }
 ignore = "0.4.20"
 libc = "0.2.144"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,16 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.3.0", features = ["derive"] }
-grep = "0.2.12"
+# grep = "0.2.12"
+# grep = { path = "../ripgrep/crates/grep" }
+grep = { git = "https://github.com/helixbass/ripgrep", rev = "b83cc3c" }
 ignore = "0.4.20"
 libc = "0.2.144"
 libloading = "0.8.0"
 once_cell = "1.17.1"
 rayon = "1.7.0"
 regex = "1.8.2"
+termcolor = "1.2.0"
 tree-sitter = "0.20.10"
 tree-sitter-rust = "0.20.3"
 tree-sitter-typescript = "0.20.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,8 +119,6 @@ fn get_printer(output_mode: OutputMode) -> grep::printer::Standard<termcolor::No
             .per_match(true)
             .per_match_one_line(true)
             .column(true)
-            .heading(false)
-            .path(true)
             .build_no_color(io::stdout()),
     }
 }

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -44,47 +44,32 @@ struct ExpectedMatch {
     pub range: Range,
 }
 
-impl ExpectedMatch {
-    pub fn expected_output_text(&self) -> String {
-        self.lines
-            .iter()
-            .enumerate()
-            .map(|(line_index, line)| {
-                format!(
-                    "{}:{}:{}",
-                    self.relative_file_path,
-                    self.range.start.line + line_index + 1,
-                    line
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-}
-
 const MATCH_OUTPUT_LINE_REGEX_STR: &'static str = r#"(^|\n).+:\d+:"#;
 
-fn predicate_from_expected_matches(expected_matches: &[ExpectedMatch]) -> BoxPredicate<str> {
+fn predicate_from_expected_matches(
+    expected_matches: &[ExpectedMatch],
+    output_mode: OutputMode,
+) -> BoxPredicate<str> {
     expected_matches.into_iter().fold(
         BoxPredicate::new(
             predicate::str::is_match(MATCH_OUTPUT_LINE_REGEX_STR)
                 .unwrap()
-                .count(
-                    expected_matches
-                        .into_iter()
-                        .map(|expected_match| expected_match.lines.len())
-                        .sum(),
-                ),
+                .count(output_mode.get_expected_total_number_of_match_lines(expected_matches)),
         ),
         |predicate, expected_match| {
-            BoxPredicate::new(predicate.and(predicate_from_expected_match(expected_match)))
+            BoxPredicate::new(
+                predicate.and(predicate_from_expected_match(expected_match, output_mode)),
+            )
         },
     )
 }
 
-fn predicate_from_expected_match(expected_match: &ExpectedMatch) -> BoxPredicate<str> {
+fn predicate_from_expected_match(
+    expected_match: &ExpectedMatch,
+    output_mode: OutputMode,
+) -> BoxPredicate<str> {
     BoxPredicate::new(predicate::str::contains(
-        expected_match.expected_output_text(),
+        output_mode.expected_output_text(expected_match),
     ))
 }
 
@@ -92,6 +77,7 @@ fn assert_expected_matches<TArg: AsRef<OsStr>>(
     args: impl IntoIterator<Item = TArg>,
     current_dir: impl AsRef<Path>,
     expected_matches: &[ExpectedMatch],
+    output_mode: OutputMode,
 ) {
     Command::cargo_bin("tree-sitter-grep")
         .unwrap()
@@ -99,7 +85,65 @@ fn assert_expected_matches<TArg: AsRef<OsStr>>(
         .current_dir(current_dir)
         .assert()
         .success()
-        .stdout(predicate_from_expected_matches(expected_matches));
+        .stdout(predicate_from_expected_matches(
+            expected_matches,
+            output_mode,
+        ));
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum OutputMode {
+    Normal,
+    Vimgrep,
+}
+
+impl OutputMode {
+    pub fn get_expected_total_number_of_match_lines(
+        &self,
+        expected_matches: &[ExpectedMatch],
+    ) -> usize {
+        match self {
+            Self::Normal => expected_matches
+                .into_iter()
+                .map(|expected_match| expected_match.lines.len())
+                .sum(),
+            Self::Vimgrep => expected_matches.len(),
+        }
+    }
+
+    pub fn expected_output_text(&self, expected_match: &ExpectedMatch) -> String {
+        match self {
+            Self::Normal => expected_match
+                .lines
+                .iter()
+                .enumerate()
+                .map(|(line_index, line)| {
+                    format!(
+                        "{}:{}:{}",
+                        with_leading_dot_slash(&expected_match.relative_file_path),
+                        expected_match.range.start.line + line_index + 1,
+                        line
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n"),
+            Self::Vimgrep => format!(
+                "{}:{}:{}:{}",
+                expected_match.relative_file_path,
+                expected_match.range.start.line + 1,
+                expected_match.range.start.column + 1,
+                &expected_match.lines[0]
+            ),
+        }
+    }
+}
+
+fn with_leading_dot_slash(relative_path: &str) -> String {
+    if relative_path.starts_with(".") {
+        relative_path.to_owned()
+    } else {
+        format!("./{relative_path}")
+    }
 }
 
 struct FixtureQueryExpectedMatches {
@@ -110,16 +154,21 @@ struct FixtureQueryExpectedMatches {
 }
 
 impl FixtureQueryExpectedMatches {
-    pub fn assert_expected_matches(&self) {
+    pub fn assert_expected_matches(&self, output_mode: OutputMode) {
+        let mut args = vec![
+            "--query-source",
+            &self.query_source,
+            "--language",
+            &self.language,
+        ];
+        if output_mode == OutputMode::Vimgrep {
+            args.push("--vimgrep");
+        }
         assert_expected_matches(
-            [
-                "--query-source",
-                &self.query_source,
-                "--language",
-                &self.language,
-            ],
+            args,
             get_fixture_dir_path_from_name(&self.fixture_dir_name),
             &self.expected_matches,
+            output_mode,
         );
     }
 }
@@ -142,12 +191,12 @@ static RUST_PROJECT_FUNCTION_ITEM_EXPECTED_MATCHES: Lazy<FixtureQueryExpectedMat
         language: "rust".to_owned(),
         expected_matches: vec![
             ExpectedMatch {
-                relative_file_path: "./src/helpers.rs".to_owned(),
+                relative_file_path: "src/helpers.rs".to_owned(),
                 lines: vec!["pub fn helper() {}".to_owned()],
                 range: ((0, 0), (0, 18)).into(),
             },
             ExpectedMatch {
-                relative_file_path: "./src/lib.rs".to_owned(),
+                relative_file_path: "src/lib.rs".to_owned(),
                 lines: vec![
                     "pub fn add(left: usize, right: usize) -> usize {".to_owned(),
                     "    left + right".to_owned(),
@@ -156,19 +205,24 @@ static RUST_PROJECT_FUNCTION_ITEM_EXPECTED_MATCHES: Lazy<FixtureQueryExpectedMat
                 range: ((2, 0), (5, 0)).into(),
             },
             ExpectedMatch {
-                relative_file_path: "./src/lib.rs".to_owned(),
+                relative_file_path: "src/lib.rs".to_owned(),
                 lines: vec![
                     "    fn it_works() {".to_owned(),
                     "        let result = add(2, 2);".to_owned(),
                     "        assert_eq!(result, 4);".to_owned(),
                     "    }".to_owned(),
                 ],
-                range: ((11, 0), (14, 4)).into(),
+                range: ((11, 4), (14, 4)).into(),
             },
         ],
     });
 
 #[test]
 fn test_query_inline() {
-    RUST_PROJECT_FUNCTION_ITEM_EXPECTED_MATCHES.assert_expected_matches();
+    RUST_PROJECT_FUNCTION_ITEM_EXPECTED_MATCHES.assert_expected_matches(OutputMode::Normal);
+}
+
+#[test]
+fn test_vimgrep_mode() {
+    RUST_PROJECT_FUNCTION_ITEM_EXPECTED_MATCHES.assert_expected_matches(OutputMode::Vimgrep);
 }


### PR DESCRIPTION
In this PR:
- add support for `--vimgrep` command-line option

Not in this PR:
- I believe this should set me up to more easily write some sort of (neo)vim plugin wrapper to eg show matches in the quickfix list but I haven't tried that/am not super familiar with what's involved in doing that

To test:
If you run any previously-working command-line with `--vimgrep` added, you should see matches formatted like:
```
path/without/leading/dot/slash.rs:line:column:line contents
```
(where if the matched AST node spans multiple lines only the first line is included in the formatted output)

`cargo test` should pass

Based on `test-matches`