### PR TITLE
test sorted output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ name = "tree-sitter-grep"
 [dev-dependencies]
 assert_cmd = "2.0.11"
 predicates = "3.0.3"
+shlex = "1.1.0"


### PR DESCRIPTION
In this PR:
- per [this comment](https://github.com/helixbass/tree-sitter-grep/pull/17#discussion_r1222321526) switch to a simpler "parsed command + output" style for integration tests of whether matches are output as expected

To test:
Tests should still pass

Based on `vimgrep-mode`