### PR TITLE
Run GitHub Actions on Ubuntu and Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
           rustup toolchain install nightly --allow-downgrade -c rustfmt
       - uses: Swatinem/rust-cache@v2
       - run: cargo +nightly fmt -- --check
+        if: matrix.os == 'ubuntu-latest'
       - run: cargo clippy --all-targets --tests -- -D warnings
       - run: cargo test
       - run: RUSTDOCFLAGS='--deny warnings' cargo doc --no-deps
+        if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,10 @@ on:
     branches: ["*"]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -1,8 +1,12 @@
 #![allow(clippy::into_iter_on_ref, clippy::collapsible_if)]
+#[cfg(windows)]
+use std::borrow::Cow;
 use std::{env, path::PathBuf, process::Command};
 
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
+#[cfg(windows)]
+use regex::Captures;
 
 #[macro_export]
 macro_rules! regex {
@@ -80,8 +84,33 @@ fn assert_sorted_output(fixture_dir_name: &str, command_and_output: &str) {
         }));
 }
 
+#[cfg(unix)]
+fn massage_windows_line(line: &str) -> String {
+    line.to_owned()
+}
+
+#[cfg(windows)]
+fn massage_windows_line(line: &str) -> String {
+    let line = strip_trailing_carriage_return(line);
+    let line = normalize_match_path(line);
+    line.to_owned()
+}
+
+#[cfg(windows)]
+fn strip_trailing_carriage_return(line: &str) -> Cow<'_, str> {
+    regex!(r#"\r$"#).replace(line, "")
+}
+
+#[cfg(windows)]
+fn normalize_match_path(line: &str) -> Cow<'_, str> {
+    regex!(r#"^([^:]+):"#).replace(line, |captures: &Captures| captures[1].replace('\\', "/"))
+}
+
 fn do_sorted_lines_match(actual_output: &str, expected_output: &str) -> bool {
-    let mut actual_lines = actual_output.split('\n').collect::<Vec<_>>();
+    let mut actual_lines = actual_output
+        .split('\n')
+        .map(massage_windows_line)
+        .collect::<Vec<_>>();
     actual_lines.sort();
     let mut expected_lines = expected_output.split('\n').collect::<Vec<_>>();
     expected_lines.sort();

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -92,8 +92,8 @@ fn massage_windows_line(line: &str) -> String {
 #[cfg(windows)]
 fn massage_windows_line(line: &str) -> String {
     let line = strip_trailing_carriage_return(line);
-    let line = normalize_match_path(line);
-    line.to_owned()
+    let line = normalize_match_path(&line);
+    line.into_owned()
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
@helixbass It looks to me like everything basically works (in that the output I see in the tests look reasonable), but the test code is going to have to be able standardize the output before comparing it against the snapshots. That looks like it might just be:
- stripping out carriage returns ("\r") at the end of lines
- handling back- vs forward-slashes