### PR TITLE
Test filter plugins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,14 @@ name = "tree-sitter-grep"
 
 [dev-dependencies]
 assert_cmd = "2.0.11"
+escargot = "0.5.7"
 predicates = "3.0.3"
 shlex = "1.1.0"
+
+[[example]]
+name = "filter_before_line_number"
+crate-type = ["cdylib"]
+
+[[example]]
+name = "filter_before_line_10"
+crate-type = ["cdylib"]

--- a/examples/filter_before_line_10.rs
+++ b/examples/filter_before_line_10.rs
@@ -1,0 +1,6 @@
+use tree_sitter::Node;
+
+#[no_mangle]
+pub extern "C" fn filterer(node: &Node) -> bool {
+    node.start_position().row < 10
+}

--- a/examples/filter_before_line_number.rs
+++ b/examples/filter_before_line_number.rs
@@ -1,0 +1,25 @@
+use std::{
+    ffi::CStr,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use libc::c_char;
+use tree_sitter::Node;
+
+static ROW_NUMBER: AtomicUsize = AtomicUsize::new(0);
+
+#[no_mangle]
+pub extern "C" fn initialize(value: *const c_char) {
+    assert!(!value.is_null(), "Expected filter argument");
+    let value: usize = unsafe { CStr::from_ptr(value) }
+        .to_str()
+        .unwrap()
+        .parse()
+        .expect("Expected filter argument to be a usize");
+    ROW_NUMBER.store(value, Ordering::Relaxed);
+}
+
+#[no_mangle]
+pub extern "C" fn filterer(node: &Node) -> bool {
+    node.start_position().row < ROW_NUMBER.load(Ordering::Relaxed)
+}

--- a/examples/filter_before_line_number.rs
+++ b/examples/filter_before_line_number.rs
@@ -8,6 +8,7 @@ use tree_sitter::Node;
 
 static ROW_NUMBER: AtomicUsize = AtomicUsize::new(0);
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
 pub extern "C" fn initialize(value: *const c_char) {
     assert!(!value.is_null(), "Expected filter argument");

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -5,7 +5,6 @@ use std::{env, path::PathBuf, process::Command};
 
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
-#[cfg(windows)]
 use regex::Captures;
 
 #[macro_export]

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -508,3 +508,17 @@ fn test_filter_plugin() {
         "#,
     );
 }
+
+#[test]
+fn test_filter_plugin_with_argument() {
+    build_example("filter_before_line_number");
+
+    assert_sorted_output(
+        "rust_project",
+        r#"
+            $ tree-sitter-grep --query-source '(function_item) @function_item' --language rust --filter ../../../target/debug/examples/libfilter_before_line_number.so --filter-arg 2
+            src/helpers.rs:1:pub fn helper() {}
+            src/stop.rs:1:fn stop_it() {}
+        "#,
+    );
+}

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -74,14 +74,25 @@ const DYNAMIC_LIBRARY_EXTENSION: &str = ".so";
 #[cfg(windows)]
 const DYNAMIC_LIBRARY_EXTENSION: &str = ".dll";
 
+#[cfg(unix)]
+fn get_dynamic_library_name(library_name: &str) -> String {
+    format!("lib{library_name}{}", DYNAMIC_LIBRARY_EXTENSION)
+}
+#[cfg(windows)]
+fn get_dynamic_library_name(library_name: &str) -> String {
+    format!("{library_name}{}", DYNAMIC_LIBRARY_EXTENSION)
+}
+
 fn parse_command_line(command_line: &str) -> Vec<String> {
     assert!(command_line.starts_with('$'));
     shlex::split(&command_line[1..])
         .unwrap()
         .iter()
         .map(|arg| {
-            regex!(r#"\.so$"#)
-                .replace(arg, DYNAMIC_LIBRARY_EXTENSION)
+            regex!(r#"lib(\S+)\.so$"#)
+                .replace(arg, |captures: &Captures| {
+                    get_dynamic_library_name(&captures[1])
+                })
                 .into_owned()
         })
         .collect()


### PR DESCRIPTION
In this PR:
- add some "success case" tests for filter plugins packaged as `examples/`

Not in this PR:
- it seems worth trying to make the "plugin failed because of missing/invalid filter argument" case fail more nicely (vs panicking in FFI-world), so maybe that involves eg encoding a failure code in the return value of the `initialize()` plugin function and translating that into a `Result`? But that sounds like a bit of a refactor so kept it separate

To test:
You should be able to build the examples in `examples` as normally expected (eg `cargo build --example whatever`)
If you completely remove your local `target/` directory and then run `cargo test` it should pass (implying that it successfully built the filter plugins while running `cargo test`, I think)