### PR TITLE
Test filter plugin: failure

### DIFF
--- a/examples/filter_before_line_number.rs
+++ b/examples/filter_before_line_number.rs
@@ -5,10 +5,7 @@ use std::{
 
 use libc::c_char;
 use tree_sitter::Node;
-use tree_sitter_grep::{
-    PluginInitializeReturn, PLUGIN_INITIALIZE_ARGUMENT_NOT_PARSEABLE,
-    PLUGIN_INITIALIZE_MISSING_EXPECTED_ARGUMENT, PLUGIN_INITIALIZE_SUCCEEDED,
-};
+use tree_sitter_grep::PluginInitializeReturn;
 
 static ROW_NUMBER: AtomicUsize = AtomicUsize::new(0);
 
@@ -16,16 +13,16 @@ static ROW_NUMBER: AtomicUsize = AtomicUsize::new(0);
 #[no_mangle]
 pub extern "C" fn initialize(value: *const c_char) -> PluginInitializeReturn {
     if value.is_null() {
-        return PLUGIN_INITIALIZE_MISSING_EXPECTED_ARGUMENT;
+        return PluginInitializeReturn::MissingArgument;
     }
     let value: usize = match unsafe { CStr::from_ptr(value) }.to_str().unwrap().parse() {
         Err(_) => {
-            return PLUGIN_INITIALIZE_ARGUMENT_NOT_PARSEABLE;
+            return PluginInitializeReturn::NotParseable;
         }
         Ok(value) => value,
     };
     ROW_NUMBER.store(value, Ordering::Relaxed);
-    PLUGIN_INITIALIZE_SUCCEEDED
+    PluginInitializeReturn::Succeeded
 }
 
 #[no_mangle]

--- a/examples/filter_before_line_number.rs
+++ b/examples/filter_before_line_number.rs
@@ -5,19 +5,27 @@ use std::{
 
 use libc::c_char;
 use tree_sitter::Node;
+use tree_sitter_grep::{
+    PluginInitializeReturn, PLUGIN_INITIALIZE_ARGUMENT_NOT_PARSEABLE,
+    PLUGIN_INITIALIZE_MISSING_EXPECTED_ARGUMENT, PLUGIN_INITIALIZE_SUCCEEDED,
+};
 
 static ROW_NUMBER: AtomicUsize = AtomicUsize::new(0);
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[no_mangle]
-pub extern "C" fn initialize(value: *const c_char) {
-    assert!(!value.is_null(), "Expected filter argument");
-    let value: usize = unsafe { CStr::from_ptr(value) }
-        .to_str()
-        .unwrap()
-        .parse()
-        .expect("Expected filter argument to be a usize");
+pub extern "C" fn initialize(value: *const c_char) -> PluginInitializeReturn {
+    if value.is_null() {
+        return PLUGIN_INITIALIZE_MISSING_EXPECTED_ARGUMENT;
+    }
+    let value: usize = match unsafe { CStr::from_ptr(value) }.to_str().unwrap().parse() {
+        Err(_) => {
+            return PLUGIN_INITIALIZE_ARGUMENT_NOT_PARSEABLE;
+        }
+        Ok(value) => value,
+    };
     ROW_NUMBER.store(value, Ordering::Relaxed);
+    PLUGIN_INITIALIZE_SUCCEEDED
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,10 @@ use language::{
     SupportedLanguageName,
 };
 use plugin::get_loaded_filter;
+pub use plugin::{
+    PluginInitializeReturn, PLUGIN_INITIALIZE_ARGUMENT_NOT_PARSEABLE,
+    PLUGIN_INITIALIZE_MISSING_EXPECTED_ARGUMENT, PLUGIN_INITIALIZE_SUCCEEDED,
+};
 use treesitter::{get_matches, maybe_get_query};
 
 #[derive(Parser)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,10 +37,7 @@ use language::{
     SupportedLanguageName,
 };
 use plugin::get_loaded_filter;
-pub use plugin::{
-    PluginInitializeReturn, PLUGIN_INITIALIZE_ARGUMENT_NOT_PARSEABLE,
-    PLUGIN_INITIALIZE_MISSING_EXPECTED_ARGUMENT, PLUGIN_INITIALIZE_SUCCEEDED,
-};
+pub use plugin::PluginInitializeReturn;
 use treesitter::{get_matches, maybe_get_query};
 
 #[derive(Parser)]

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -25,10 +25,12 @@ impl Filterer {
     }
 }
 
-pub type PluginInitializeReturn = u32;
-pub const PLUGIN_INITIALIZE_ARGUMENT_NOT_PARSEABLE: u32 = 2;
-pub const PLUGIN_INITIALIZE_MISSING_EXPECTED_ARGUMENT: u32 = 1;
-pub const PLUGIN_INITIALIZE_SUCCEEDED: u32 = 0;
+#[repr(u8)]
+pub enum PluginInitializeReturn {
+    Succeeded,
+    MissingArgument,
+    NotParseable,
+}
 
 fn load_plugin(library_path: impl AsRef<OsStr>, filter_arg: Option<&str>) -> Filterer {
     let library =
@@ -50,10 +52,10 @@ fn load_plugin(library_path: impl AsRef<OsStr>, filter_arg: Option<&str>) -> Fil
             )
         };
         match did_initialize {
-            did_initialize if did_initialize == PLUGIN_INITIALIZE_MISSING_EXPECTED_ARGUMENT => {
+            PluginInitializeReturn::MissingArgument => {
                 fail("plugin expected '--filter-arg <ARGUMENT>'");
             }
-            did_initialize if did_initialize == PLUGIN_INITIALIZE_ARGUMENT_NOT_PARSEABLE => {
+            PluginInitializeReturn::NotParseable => {
                 fail(&format!(
                     "plugin couldn't parse argument {:?}",
                     filter_arg.unwrap()

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -532,3 +532,29 @@ fn test_filter_plugin_with_argument() {
         "#,
     );
 }
+
+#[test]
+fn test_filter_plugin_expecting_argument_not_received() {
+    build_example("filter_before_line_number");
+
+    assert_failure_output(
+        "rust_project",
+        r#"
+            $ tree-sitter-grep --query-source '(function_item) @function_item' --language rust --filter ../../../target/debug/examples/libfilter_before_line_number.so
+            error: plugin expected '--filter-arg <ARGUMENT>'
+        "#,
+    );
+}
+
+#[test]
+fn test_filter_plugin_unparseable_argument() {
+    build_example("filter_before_line_number");
+
+    assert_failure_output(
+        "rust_project",
+        r#"
+            $ tree-sitter-grep --query-source '(function_item) @function_item' --language rust --filter ../../../target/debug/examples/libfilter_before_line_number.so --filter-arg abc
+            error: plugin couldn't parse argument "abc"
+        "#,
+    );
+}


### PR DESCRIPTION
In this PR:
- make the `initialize()` filter plugin function return a value that encodes whether/how it succeeded/failed
- tests for that

To test:
You should be able to manually mimic what the newly added tests are doing as far as returning an error from a filter plugin if it isn't given an argument that it expects that gets printed "cleanly"

Based on `test-filter-plugin`