### PR TITLE
Support "no query" (with filter) mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,7 @@ crate-type = ["cdylib"]
 [[example]]
 name = "filter_before_line_10"
 crate-type = ["cdylib"]
+
+[[example]]
+name = "filter_function_items_before_line_10"
+crate-type = ["cdylib"]

--- a/examples/filter_function_items_before_line_10.rs
+++ b/examples/filter_function_items_before_line_10.rs
@@ -1,0 +1,6 @@
+use tree_sitter::Node;
+
+#[no_mangle]
+pub extern "C" fn filterer(node: &Node) -> bool {
+    node.kind() == "function_item" && node.start_position().row < 10
+}


### PR DESCRIPTION
In this PR:
- allow not passing any "query" argument if you pass a filter argument (and use a default "pass all AST nodes through to the filter" query in that case)
- futz with `clap` a little bit

To test:
You should be able to build + run example filters (I added a new one which at least limits the AST node types that it produces matches for, I didn't try running in non-query mode for one of the existing ones but that is presumably a lot of AST nodes matched) with or without also passing a query argument
Per the tests the output produced by `clap` eg when doing `--help`, not passing required arguments or passing an unrecognized argument shouldn't be too insane/unhelpful