### PR TITLE
Use OnceLock for capture index

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,7 @@ use std::{
     fs,
     path::Path,
     process,
-    sync::{
-        atomic::{AtomicU32, Ordering},
-        Arc, OnceLock,
-    },
+    sync::{Arc, OnceLock},
     thread,
     time::Duration,
 };
@@ -38,72 +35,29 @@ use project_file_walker::get_project_file_parallel_iterator;
 use searcher::get_searcher;
 use treesitter::maybe_get_query;
 
-struct MaybeInitializedCaptureIndex(AtomicU32);
+#[derive(Default)]
+struct CaptureIndex(OnceLock<Result<u32, ()>>);
 
-impl MaybeInitializedCaptureIndex {
-    const UNINITIALIZED: u32 = u32::MAX;
-    const FAILED: u32 = u32::MAX - 1;
-
-    fn mark_failed(&self) -> bool {
-        loop {
-            let existing_value = self.0.load(Ordering::Relaxed);
-            if existing_value == Self::FAILED {
-                return false;
-            }
-            let did_store = self.0.compare_exchange(
-                existing_value,
-                Self::FAILED,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            );
-            if did_store.is_ok() {
-                return true;
-            }
-        }
-    }
-
-    pub fn get(&self) -> Result<Option<u32>, ()> {
-        let loaded = self.0.load(Ordering::Relaxed);
-        match loaded {
-            loaded if loaded == Self::UNINITIALIZED => Ok(None),
-            loaded if loaded == Self::FAILED => Err(()),
-            loaded => Ok(Some(loaded)),
-        }
-    }
-
-    pub fn get_or_initialize(&self, query: &Query, capture_name: Option<&str>) -> Result<u32, ()> {
-        if let Some(already_initialized) = self.get()? {
-            return Ok(already_initialized);
-        }
-        let capture_index = match capture_name {
-            None => 0,
-            Some(capture_name) => {
-                let capture_index = query.capture_index_for_name(capture_name);
-                if capture_index.is_none() {
-                    let did_mark_failed = self.mark_failed();
-                    if did_mark_failed {
-                        fail(&format!("invalid capture name '{}'", capture_name));
-                    } else {
-                        // whichever other thread "won the race" will have called this fail()
-                        // so we'll be getting killed shortly?
-                        thread::sleep(Duration::from_millis(100_000));
-                    }
+impl CaptureIndex {
+    pub fn get_or_init(&self, query: &Query, capture_name: Option<&str>) -> u32 {
+        let mut did_mark_failed = false;
+        self.0
+            .get_or_init(|| match capture_name {
+                None => Ok(0),
+                Some(capture_name) => query.capture_index_for_name(capture_name).ok_or_else(|| {
+                    did_mark_failed = true;
+                    Default::default()
+                }),
+            })
+            .unwrap_or_else(|_| {
+                if did_mark_failed {
+                    fail(&format!("invalid capture name '{}'", capture_name.unwrap()));
                 }
-                capture_index.unwrap()
-            }
-        };
-        self.set(capture_index);
-        Ok(capture_index)
-    }
-
-    fn set(&self, capture_index: u32) {
-        self.0.store(capture_index, Ordering::Relaxed);
-    }
-}
-
-impl Default for MaybeInitializedCaptureIndex {
-    fn default() -> Self {
-        Self(AtomicU32::new(Self::UNINITIALIZED))
+                // whichever (other?) thread "won the race" will have called fail()
+                // so we'll be getting killed shortly?
+                thread::sleep(Duration::from_millis(100_000));
+                panic!("Should never get this far");
+            })
     }
 }
 
@@ -156,7 +110,7 @@ pub fn run(args: Args) {
     };
     let specified_supported_language = args.language.map(|language| language.get_language());
     let cached_queries: CachedQueries = Default::default();
-    let capture_index = MaybeInitializedCaptureIndex::default();
+    let capture_index = CaptureIndex::default();
     let output_mode = args.output_mode();
     let buffer_writer = BufferWriter::stdout(ColorChoice::Never);
 
@@ -167,9 +121,7 @@ pub fn run(args: Args) {
             let query = return_if_none!(
                 cached_queries.get_and_cache_query_for_language(&query_source, &*language)
             );
-            let capture_index = return_if_none!(capture_index
-                .get_or_initialize(&query, args.capture_name.as_deref())
-                .ok());
+            let capture_index = capture_index.get_or_init(&query, args.capture_name.as_deref());
             let printer = get_printer(&buffer_writer, output_mode);
             let mut printer = printer.borrow_mut();
             let path =


### PR DESCRIPTION
In this PR:
- get rid of the manual atomics stuff in favor of using a `OnceLock` for the "lazily initialized capture index"

To test:
Existing behavior should still work
Per earlier PR if you want to more actively try and see that the capture index never "double-prints" an error then you can eg artificially add a long delay in the calculation of the capture index (ie `.get_or_init()`) and still see that passing an unknown capture name results in a single error message being printed

Based on `extract-modules`