### PR TITLE
Macro contents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ regex = "1.8.2"
 termcolor = "1.2.0"
 tree-sitter = "0.20.10"
 tree-sitter-javascript = "0.20.0"
-tree-sitter-rust = "0.20.3"
+tree-sitter-rust = { git = "https://github.com/helixbass/tree-sitter-rust", rev = "6327788" }
 tree-sitter-typescript = "0.20.2"
 
 [lib]

--- a/tests/fixtures/match_inside_macro/foo.rs
+++ b/tests/fixtures/match_inside_macro/foo.rs
@@ -1,0 +1,8 @@
+fn whee() {
+    let x = vec![
+        // great stuff
+        self.factory
+            .create_parameter_declaration("whee", Option::<Gc<NodeArray>>::None)
+            .wrap(),
+    ];
+}

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -662,3 +662,16 @@ fn test_filter_argument_no_filter() {
         "#,
     );
 }
+
+#[test]
+fn test_macro_contents() {
+    assert_sorted_output(
+        "match_inside_macro",
+        r#"
+            $ tree-sitter-grep -q '(call_expression) @c' -l rust
+            foo.rs:4:        self.factory
+            foo.rs:5:            .create_parameter_declaration("whee", Option::<Gc<NodeArray>>::None)
+            foo.rs:6:            .wrap(),
+        "#,
+    );
+}


### PR DESCRIPTION
In this PR:
- allow querying against the contents of macro invocations (eg `println!(...)` or `vec![...]`)

To test:
If you run a query for eg `(call_expression) @whatever` against a file that contains `vec![call_something()]` it should match the `call_something()`

Based on `sort-matches`