### PR TITLE
Expose context-lines options

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -40,6 +40,15 @@ pub struct Args {
 
     #[arg(long)]
     vimgrep: bool,
+
+    #[arg(short = 'A', long, value_name = "NUM")]
+    pub after_context: Option<usize>,
+
+    #[arg(short = 'B', long, value_name = "NUM")]
+    pub before_context: Option<usize>,
+
+    #[arg(short = 'C', long, value_name = "NUM")]
+    pub context: Option<usize>,
 }
 
 impl Args {
@@ -71,9 +80,24 @@ impl Args {
         self.vimgrep
     }
 
+    fn contexts(&self) -> (usize, usize) {
+        let both = self.context.unwrap_or(0);
+        if both > 0 {
+            (both, both)
+        } else {
+            (
+                self.before_context.unwrap_or(0),
+                self.after_context.unwrap_or(0),
+            )
+        }
+    }
+
     pub(crate) fn get_searcher(&self) -> Searcher {
+        let (before_context, after_context) = self.contexts();
         SearcherBuilder::new()
             .line_number(self.line_number())
+            .before_context(before_context)
+            .after_context(after_context)
             .build()
     }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,8 +1,14 @@
 use std::path::{Path, PathBuf};
 
 use clap::{ArgGroup, Parser};
+use termcolor::BufferWriter;
 
-use crate::language::SupportedLanguageName;
+use crate::{
+    language::SupportedLanguageName,
+    printer::StandardBuilder,
+    searcher::{Searcher, SearcherBuilder},
+    use_printer::Printer,
+};
 
 #[derive(Parser)]
 #[clap(group(
@@ -49,17 +55,33 @@ impl Args {
         self.paths.is_empty()
     }
 
-    pub(crate) fn output_mode(&self) -> OutputMode {
-        if self.vimgrep {
-            OutputMode::Vimgrep
-        } else {
-            OutputMode::Normal
-        }
+    fn line_number(&self) -> bool {
+        true
     }
-}
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(crate) enum OutputMode {
-    Normal,
-    Vimgrep,
+    fn per_match(&self) -> bool {
+        self.vimgrep
+    }
+
+    fn per_match_one_line(&self) -> bool {
+        self.vimgrep
+    }
+
+    fn column(&self) -> bool {
+        self.vimgrep
+    }
+
+    pub(crate) fn get_searcher(&self) -> Searcher {
+        SearcherBuilder::new()
+            .line_number(self.line_number())
+            .build()
+    }
+
+    pub(crate) fn get_printer(&self, buffer_writer: &BufferWriter) -> Printer {
+        StandardBuilder::new()
+            .per_match(self.per_match())
+            .per_match_one_line(self.per_match_one_line())
+            .column(self.column())
+            .build(buffer_writer.buffer())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@ mod use_printer;
 mod use_searcher;
 
 pub use args::Args;
-use args::OutputMode;
 use language::{
     get_all_supported_languages, maybe_supported_language_from_path, SupportedLanguage,
     SupportedLanguageName,
@@ -117,7 +116,6 @@ pub fn run(args: Args) {
     let specified_supported_language = args.language.map(|language| language.get_language());
     let cached_queries: CachedQueries = Default::default();
     let capture_index = CaptureIndex::default();
-    let output_mode = args.output_mode();
     let buffer_writer = BufferWriter::stdout(ColorChoice::Never);
 
     get_project_file_parallel_iterator(specified_supported_language.as_deref(), &args.use_paths())
@@ -128,7 +126,7 @@ pub fn run(args: Args) {
                 cached_queries.get_and_cache_query_for_language(&query_source, &*language)
             );
             let capture_index = capture_index.get_or_init(&query, args.capture_name.as_deref());
-            let printer = get_printer(&buffer_writer, output_mode);
+            let printer = get_printer(&buffer_writer, &args);
             let mut printer = printer.borrow_mut();
             let path =
                 format_relative_path(project_file_dir_entry.path(), args.is_using_default_paths());
@@ -142,7 +140,7 @@ pub fn run(args: Args) {
             );
 
             printer.get_mut().clear();
-            get_searcher(output_mode)
+            get_searcher(&args)
                 .borrow_mut()
                 .search_path(query_context, path, printer.sink_with_path(path))
                 .unwrap();

--- a/src/printer/standard.rs
+++ b/src/printer/standard.rs
@@ -218,6 +218,7 @@ pub struct Standard<W> {
 }
 
 impl<W: WriteColor> Standard<W> {
+    #[allow(dead_code)]
     pub fn new(wtr: W) -> Standard<W> {
         StandardBuilder::new().build(wtr)
     }

--- a/src/treesitter/mod.rs
+++ b/src/treesitter/mod.rs
@@ -1,6 +1,6 @@
-use tree_sitter::{Language, Node, Parser, Query, QueryCursor};
+use tree_sitter::{Language, Node, Parser, Query};
 
-use crate::{matcher::Match, plugin::Filterer};
+use crate::matcher::Match;
 
 pub(crate) fn get_parser(language: Language) -> Parser {
     let mut parser = Parser::new();

--- a/tests/fixtures/rust_overlapping/src/lib.rs
+++ b/tests/fixtures/rust_overlapping/src/lib.rs
@@ -5,3 +5,10 @@ pub fn has_overlapping() {
         }
     };
 }
+
+fn something_else() {
+    hello();
+    hoo();
+    raa();
+    roo();
+}

--- a/tests/fixtures/rust_overlapping_with_preceding_lines/src/lib.rs
+++ b/tests/fixtures/rust_overlapping_with_preceding_lines/src/lib.rs
@@ -1,0 +1,12 @@
+pub fn has_overlapping() {
+    let something_before = whoo()
+        .ok()
+        .this_isnt_real_code()
+        .i_promise()
+        .but_it_has_to_be_longer();
+    let f = || {
+        || {
+            println!("whee");
+        }
+    };
+}

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -786,3 +786,238 @@ fn test_after_context_overlapping_multiline_matches_vimgrep() {
         "#,
     );
 }
+
+#[test]
+fn test_after_context_short_option() {
+    assert_sorted_output(
+        "rust_project",
+        r#"
+            $ tree-sitter-grep -q '(function_item) @f' -l rust -A 2
+            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:1:pub fn helper() {}
+            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:4:    left + right
+            src/lib.rs:5:}
+            src/lib.rs-6-
+            src/lib.rs-7-#[cfg(test)]
+            --
+            src/lib.rs:12:    fn it_works() {
+            src/lib.rs:13:        let result = add(2, 2);
+            src/lib.rs:14:        assert_eq!(result, 4);
+            src/lib.rs:15:    }
+            src/lib.rs-16-}
+            src/lib.rs-17-
+        "#,
+    );
+}
+
+#[test]
+fn test_before_context() {
+    assert_sorted_output(
+        "rust_project",
+        r#"
+            $ tree-sitter-grep -q '(function_item) @f' -l rust --before-context 3
+            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:1:pub fn helper() {}
+            src/lib.rs-1-mod helpers;
+            src/lib.rs-2-
+            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:4:    left + right
+            src/lib.rs:5:}
+            --
+            src/lib.rs-9-    use super::*;
+            src/lib.rs-10-
+            src/lib.rs-11-    #[test]
+            src/lib.rs:12:    fn it_works() {
+            src/lib.rs:13:        let result = add(2, 2);
+            src/lib.rs:14:        assert_eq!(result, 4);
+            src/lib.rs:15:    }
+        "#,
+    );
+}
+
+#[test]
+fn test_before_context_short_option() {
+    assert_sorted_output(
+        "rust_project",
+        r#"
+            $ tree-sitter-grep -q '(function_item) @f' -l rust -B 3
+            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:1:pub fn helper() {}
+            src/lib.rs-1-mod helpers;
+            src/lib.rs-2-
+            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:4:    left + right
+            src/lib.rs:5:}
+            --
+            src/lib.rs-9-    use super::*;
+            src/lib.rs-10-
+            src/lib.rs-11-    #[test]
+            src/lib.rs:12:    fn it_works() {
+            src/lib.rs:13:        let result = add(2, 2);
+            src/lib.rs:14:        assert_eq!(result, 4);
+            src/lib.rs:15:    }
+        "#,
+    );
+}
+
+#[test]
+fn test_before_context_matches_overlap_context_lines() {
+    assert_sorted_output(
+        "rust_overlapping",
+        r#"
+            $ tree-sitter-grep -q '(call_expression function: (identifier) @function_name (#match? @function_name "^h"))' -l rust -B 2
+            src/lib.rs-8-
+            src/lib.rs-9-fn something_else() {
+            src/lib.rs:10:    hello();
+            src/lib.rs:11:    hoo();
+        "#,
+    );
+}
+
+#[test]
+fn test_before_context_overlapping_matches() {
+    assert_sorted_output(
+        "rust_overlapping_with_preceding_lines",
+        r#"
+            $ tree-sitter-grep -q '(closure_expression) @c' -l rust --before-context 2
+            src/lib.rs-5-        .i_promise()
+            src/lib.rs-6-        .but_it_has_to_be_longer();
+            src/lib.rs:7:    let f = || {
+            src/lib.rs:8:        || {
+            src/lib.rs:9:            println!("whee");
+            src/lib.rs:10:        }
+            src/lib.rs:11:    };
+        "#,
+    );
+}
+
+#[test]
+fn test_before_context_overlapping_multiline_matches_vimgrep() {
+    assert_sorted_output(
+        "rust_overlapping_with_preceding_lines",
+        r#"
+            $ tree-sitter-grep -q '(closure_expression) @c' -l rust --before-context 2 --vimgrep
+            src/lib.rs-5-        .i_promise()
+            src/lib.rs-6-        .but_it_has_to_be_longer();
+            src/lib.rs:7:13:    let f = || {
+            src/lib.rs:8:9:        || {
+        "#,
+    );
+}
+
+#[test]
+fn test_context() {
+    assert_sorted_output(
+        "rust_project",
+        r#"
+            $ tree-sitter-grep -q '(function_item) @f' -l rust --context 2
+            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:1:pub fn helper() {}
+            src/lib.rs-1-mod helpers;
+            src/lib.rs-2-
+            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:4:    left + right
+            src/lib.rs:5:}
+            src/lib.rs-6-
+            src/lib.rs-7-#[cfg(test)]
+            --
+            src/lib.rs-10-
+            src/lib.rs-11-    #[test]
+            src/lib.rs:12:    fn it_works() {
+            src/lib.rs:13:        let result = add(2, 2);
+            src/lib.rs:14:        assert_eq!(result, 4);
+            src/lib.rs:15:    }
+            src/lib.rs-16-}
+            src/lib.rs-17-
+        "#,
+    );
+}
+
+#[test]
+fn test_context_adjacent_after_and_before_context_lines() {
+    assert_sorted_output(
+        "rust_project",
+        r#"
+            $ tree-sitter-grep -q '(function_item) @f' -l rust --context 3
+            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:1:pub fn helper() {}
+            src/lib.rs-1-mod helpers;
+            src/lib.rs-2-
+            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:4:    left + right
+            src/lib.rs:5:}
+            src/lib.rs-6-
+            src/lib.rs-7-#[cfg(test)]
+            src/lib.rs-8-mod tests {
+            src/lib.rs-9-    use super::*;
+            src/lib.rs-10-
+            src/lib.rs-11-    #[test]
+            src/lib.rs:12:    fn it_works() {
+            src/lib.rs:13:        let result = add(2, 2);
+            src/lib.rs:14:        assert_eq!(result, 4);
+            src/lib.rs:15:    }
+            src/lib.rs-16-}
+            src/lib.rs-17-
+            src/lib.rs-18-mod stop;
+        "#,
+    );
+}
+
+#[test]
+fn test_context_overlapping_after_and_before_context_lines() {
+    assert_sorted_output(
+        "rust_project",
+        r#"
+            $ tree-sitter-grep -q '(function_item) @f' -l rust --context 4
+            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:1:pub fn helper() {}
+            src/lib.rs-1-mod helpers;
+            src/lib.rs-2-
+            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:4:    left + right
+            src/lib.rs:5:}
+            src/lib.rs-6-
+            src/lib.rs-7-#[cfg(test)]
+            src/lib.rs-8-mod tests {
+            src/lib.rs-9-    use super::*;
+            src/lib.rs-10-
+            src/lib.rs-11-    #[test]
+            src/lib.rs:12:    fn it_works() {
+            src/lib.rs:13:        let result = add(2, 2);
+            src/lib.rs:14:        assert_eq!(result, 4);
+            src/lib.rs:15:    }
+            src/lib.rs-16-}
+            src/lib.rs-17-
+            src/lib.rs-18-mod stop;
+        "#,
+    );
+}
+
+#[test]
+fn test_context_short_option() {
+    assert_sorted_output(
+        "rust_project",
+        r#"
+            $ tree-sitter-grep -q '(function_item) @f' -l rust -C 2
+            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:1:pub fn helper() {}
+            src/lib.rs-1-mod helpers;
+            src/lib.rs-2-
+            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:4:    left + right
+            src/lib.rs:5:}
+            src/lib.rs-6-
+            src/lib.rs-7-#[cfg(test)]
+            --
+            src/lib.rs-10-
+            src/lib.rs-11-    #[test]
+            src/lib.rs:12:    fn it_works() {
+            src/lib.rs:13:        let result = add(2, 2);
+            src/lib.rs:14:        assert_eq!(result, 4);
+            src/lib.rs:15:    }
+            src/lib.rs-16-}
+            src/lib.rs-17-
+        "#,
+    );
+}

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -127,7 +127,8 @@ fn strip_trailing_carriage_return(line: &str) -> Cow<'_, str> {
 }
 
 fn normalize_match_path(line: &str) -> Cow<'_, str> {
-    regex!(r#"^[^:]+:"#).replace(line, |captures: &Captures| captures[0].replace('\\', "/"))
+    regex!(r#"^[^:]+[:-]\d+[:-]"#)
+        .replace(line, |captures: &Captures| captures[0].replace('\\', "/"))
 }
 
 fn do_sorted_lines_match(actual_output: &str, expected_output: &str) -> bool {

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -1021,3 +1021,29 @@ fn test_context_short_option() {
         "#,
     );
 }
+
+#[test]
+fn test_before_and_after_context() {
+    assert_sorted_output(
+        "rust_project",
+        r#"
+            $ tree-sitter-grep -q '(function_item) @f' -l rust --before-context 2 --after-context 1
+            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:1:pub fn helper() {}
+            src/lib.rs-1-mod helpers;
+            src/lib.rs-2-
+            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:4:    left + right
+            src/lib.rs:5:}
+            src/lib.rs-6-
+            --
+            src/lib.rs-10-
+            src/lib.rs-11-    #[test]
+            src/lib.rs:12:    fn it_works() {
+            src/lib.rs:13:        let result = add(2, 2);
+            src/lib.rs:14:        assert_eq!(result, 4);
+            src/lib.rs:15:    }
+            src/lib.rs-16-}
+        "#,
+    );
+}


### PR DESCRIPTION
In this PR:
- expose `--after-context`/`-A`, `--before-context`/`-B`, `--context`/`-C` command-line options mimicking the corresponding `ripgrep` options (for showing "contextual lines" around match lines

Not in this PR:
- `ripgrep` appears to be doing some more sophisticated "resolution" of its supplied command-line flags eg it appears that "order matters" if you specify "competing" flags (like both `--context` + `--after-context`). If we wanted to support that I _believe_ we would have to abandon the `clap`-`#[derive(...)]`-based approach (because it doesn't expose things like order of the command-line arguments to you)? So that seems like it would be a big "choice" to make but I didn't see it as super compelling to jump into that to maintain that level of `ripgrep`-"compatibility" at the moment

To test:
Per newly added test cases you should see surrounding lines around matches being printed basically the way `ripgrep` does it by default (just without color formatting) when you specify one or more (see above caveat) of the context-lines command-line options

Based on `custom-grep`