### PR TITLE
Use ignore match metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,13 @@ bytecount = "0.6"
 clap = { version = "4.3.0", features = ["derive"] }
 encoding_rs = "0.8.14"
 encoding_rs_io = "0.1.6"
-ignore = "0.4.20"
+ignore = { git = "https://github.com/helixbass/ripgrep", rev = "e811564" }
 libc = "0.2.144"
 libloading = "0.8.0"
 log = "0.4.5"
 memchr = "2.1"
 memmap = { package = "memmap2", version = "0.5.3" }
+once_cell = "1.18.0"
 rayon = "1.7.0"
 regex = "1.8.2"
 serde = { version = "1.0.77", features = ["derive"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -35,7 +35,7 @@ pub struct Args {
     pub capture_name: Option<String>,
 
     #[arg(short, long, value_enum)]
-    pub language: Option<SupportedLanguageName>,
+    language: Option<SupportedLanguageName>,
 
     #[arg(short, long)]
     pub filter: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,17 @@ pub fn run(args: Args) {
         |(project_file_dir_entry, matched_languages)| {
             searched.store(true, Ordering::SeqCst);
             if matched_languages.is_empty() {
-                error_explicit_path_argument_not_of_known_type(&project_file_dir_entry);
+                match args.language() {
+                    Some(language) => {
+                        error_explicit_path_argument_not_of_specified_type(
+                            &project_file_dir_entry,
+                            language,
+                        );
+                    }
+                    None => {
+                        error_explicit_path_argument_not_of_known_type(&project_file_dir_entry);
+                    }
+                }
                 return;
             }
             let language = return_if_none!(if matched_languages.len() > 1
@@ -246,8 +256,21 @@ fn error_explicit_path_argument_not_of_known_type(project_file_dir_entry: &DirEn
     // TODO: assert the assumed invariant that this was in fact an explicitly-passed
     // path?
     err_message!(
-        "File not of known type: {:?}",
+        "File {:?} does not belong to a recognized language",
         project_file_dir_entry.path()
+    );
+}
+
+fn error_explicit_path_argument_not_of_specified_type(
+    project_file_dir_entry: &DirEntry,
+    language: SupportedLanguage,
+) {
+    // TODO: assert the assumed invariant that this was in fact an explicitly-passed
+    // path?
+    err_message!(
+        "File {:?} is not recognized as a {:?} file",
+        project_file_dir_entry.path(),
+        language.name
     );
 }
 

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -1148,32 +1148,35 @@ fn test_nonexistent_directory_specified() {
     );
 }
 
-// #[test]
-// fn test_specify_explicit_file_but_dont_match_specified_language() {
-//     assert_failure_output(
-//         "mixed_project",
-//         r#"
-//             $ tree-sitter-grep -q '(function_item) @f' --language rust
-// javascript_src/index.js         "#,
-//     );
-// }
+#[test]
+fn test_specify_explicit_file_but_dont_match_specified_language() {
+    assert_failure_output(
+        "mixed_project",
+        r#"
+            $ tree-sitter-grep -q '(function_item) @f' --language rust javascript_src/index.js
+            File "javascript_src/index.js" is not recognized as a Rust file
+        "#,
+    );
+}
 
-// #[test]
-// fn test_specify_explicit_file_of_unrecognized_file_type() {
-//     assert_failure_output(
-//         "no_recognized_file_types",
-//         r#"
-//             $ tree-sitter-grep -q '(function_item) @f' something.scala
-//         "#,
-//     );
-// }
+#[test]
+fn test_specify_explicit_file_of_unrecognized_file_type() {
+    assert_failure_output(
+        "no_recognized_file_types",
+        r#"
+            $ tree-sitter-grep -q '(function_item) @f' something.scala
+            File "something.scala" does not belong to a recognized language
+        "#,
+    );
+}
 
-// #[test]
-// fn test_specify_explicit_file_of_unrecognized_file_type_and_language_flag() {
-//     assert_failure_output(
-//         "no_recognized_file_types",
-//         r#"
-//             $ tree-sitter-grep -q '(function_item) @f' --language rust
-// something.scala         "#,
-//     );
-// }
+#[test]
+fn test_specify_explicit_file_of_unrecognized_file_type_and_language_flag() {
+    assert_failure_output(
+        "no_recognized_file_types",
+        r#"
+            $ tree-sitter-grep -q '(function_item) @f' --language rust something.scala
+            File "something.scala" is not recognized as a Rust file
+        "#,
+    );
+}


### PR DESCRIPTION
In this PR:
- use a forked version of `ignore` (https://github.com/helixbass/ripgrep/pull/1) which exposes "match metadata" of which specified file-types a given project file that `ignore` returns matched

Not in this PR:
- I haven't added any tests in `ignore` for the newly exposed functionality, I'd like to treat that as a separate task

To test:
Existing behavior should still work and now per newly added test cases you should be able to get different error messages around eg specifying a file path whose type disagrees with the language you specified

Based on `error-invalid-paths`