### PR TITLE
Fail on no captures

### DIFF
--- a/tests/output.rs
+++ b/tests/output.rs
@@ -1113,3 +1113,14 @@ fn test_only_matching_multiline_overlapping_matches_starting_on_same_line() {
         "#,
     );
 }
+
+#[test]
+fn test_no_captures() {
+    assert_failure_output(
+        "rust_project",
+        r#"
+            $ tree-sitter-grep -q '(function_item)' --language rust
+            error: query must include at least one capture ("@whatever")
+        "#,
+    );
+}


### PR DESCRIPTION
In this PR:
- fail "nicely" if the provided query contains no captures

Closes #44 

To test:
If you try passing a query with no captures in it eg `-q (function_item)` then it should print an error message (only once) that there must be at least one capture in the query and then exit with an error status code

Based on `byte-offset`