### PR TITLE
Proof-of-concept of exposing crate-level "push"-style API

### DIFF
--- a/examples/print_match_text.rs
+++ b/examples/print_match_text.rs
@@ -1,0 +1,13 @@
+use clap::Parser;
+use tree_sitter_grep::{run_with_callback, Args};
+
+fn main() {
+    let args = Args::parse_from(["tree_sitter_grep", "-q", "(function_item) @f"]);
+    run_with_callback(args, |node, file_contents, path| {
+        println!(
+            "Found match in {path:?}: {}",
+            std::str::from_utf8(&file_contents[node.byte_range()]).unwrap(),
+        );
+    })
+    .unwrap();
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,5 @@
 use std::{
+    fs,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
@@ -10,14 +11,17 @@ use termcolor::BufferWriter;
 
 use crate::{
     language::SupportedLanguage,
+    plugin::{get_loaded_filter, Filterer},
     printer::StandardBuilder,
     project_file_walker::{
         get_project_file_walker_types, into_parallel_iterator, WalkParallelIterator,
     },
     searcher::{Searcher, SearcherBuilder},
     use_printer::Printer,
-    NonFatalSearchError,
+    Error, NonFatalSearchError,
 };
+
+const ALL_NODES_QUERY: &str = "(_) @node";
 
 #[derive(Parser)]
 #[clap(group(
@@ -189,5 +193,24 @@ impl Args {
         non_fatal_errors: Arc<Mutex<Vec<NonFatalSearchError>>>,
     ) -> IterBridge<WalkParallelIterator> {
         into_parallel_iterator(self.get_project_file_walker(), non_fatal_errors)
+    }
+
+    pub(crate) fn get_loaded_filter(&self) -> Result<Option<Arc<Filterer>>, Error> {
+        Ok(get_loaded_filter(self.filter.as_deref(), self.filter_arg.as_deref())?.map(Arc::new))
+    }
+
+    pub(crate) fn get_loaded_query_text(&self) -> Result<String, Error> {
+        Ok(
+            match (self.path_to_query_file.as_ref(), self.query_text.as_ref()) {
+                (Some(path_to_query_file), None) => fs::read_to_string(path_to_query_file)
+                    .map_err(|source| Error::QueryFileReadError {
+                        source,
+                        path_to_query_file: path_to_query_file.clone(),
+                    })?,
+                (None, Some(query_text)) => query_text.clone(),
+                (None, None) => ALL_NODES_QUERY.to_owned(),
+                _ => unreachable!(),
+            },
+        )
     }
 }

--- a/src/bin/tree-sitter-grep.rs
+++ b/src/bin/tree-sitter-grep.rs
@@ -1,11 +1,11 @@
 use std::process;
 
 use clap::Parser;
-use tree_sitter_grep::{run, Args, RunStatus};
+use tree_sitter_grep::{run_print, Args, RunStatus};
 
 pub fn main() {
     let args = Args::parse();
-    match run(args) {
+    match run_print(args) {
         Ok(RunStatus {
             non_fatal_errors,
             matched,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,7 @@ impl OutputContext {
 pub fn run(args: Args) -> Result<RunStatus, Error> {
     run_for_context(
         args,
-        || OutputContext::new(BufferWriter::stdout(ColorChoice::Never)),
+        OutputContext::new(BufferWriter::stdout(ColorChoice::Never)),
         |context: &OutputContext,
          args: &Args,
          path: &Path,
@@ -285,7 +285,7 @@ pub fn run(args: Args) -> Result<RunStatus, Error> {
 
 fn run_for_context<TContext: Sync>(
     args: Args,
-    initialize_context: impl FnOnce() -> TContext,
+    context: TContext,
     search_file: impl Fn(&TContext, &Args, &Path, QueryContext, &AtomicBool) + Sync,
 ) -> Result<RunStatus, Error> {
     let query_text = args.get_loaded_query_text()?;
@@ -295,7 +295,6 @@ fn run_for_context<TContext: Sync>(
     let matched = AtomicBool::new(false);
     let searched = AtomicBool::new(false);
     let non_fatal_errors: Arc<Mutex<Vec<NonFatalSearchError>>> = Default::default();
-    let context = initialize_context();
 
     for_each_project_file(
         &args,

--- a/src/searcher/mod.rs
+++ b/src/searcher/mod.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use encoding_rs_io::DecodeReaderBytesBuilder;
+use tree_sitter::{Node, QueryCursor};
 
 pub use self::mmap::MmapChoice;
 use crate::{
@@ -17,6 +18,7 @@ use crate::{
     query_context::QueryContext,
     searcher::glue::MultiLine,
     sink::{Sink, SinkError},
+    treesitter::get_parser,
 };
 
 mod core;
@@ -212,6 +214,20 @@ impl Searcher {
         self.search_file_maybe_path(query_context, Some(path), &file, write_to)
     }
 
+    pub fn search_path_callback<P>(
+        &mut self,
+        query_context: QueryContext,
+        path: P,
+        callback: impl Fn(Node, &[u8]),
+    ) -> Result<(), io::Error>
+    where
+        P: AsRef<Path>,
+    {
+        let path = path.as_ref();
+        let file = File::open(path)?;
+        self.search_file_maybe_path_callback(query_context, Some(path), &file, callback)
+    }
+
     #[allow(dead_code)]
     pub fn search_file<S>(
         &mut self,
@@ -240,7 +256,9 @@ impl Searcher {
             return self.search_slice(query_context, &mmap, write_to);
         }
         log::trace!("{:?}: reading entire file on to heap for mulitline", path);
-        self.fill_multi_line_buffer_from_file::<S>(file)?;
+
+        self.fill_multi_line_buffer_from_file(file)
+            .map_err(S::Error::error_io)?;
         log::trace!("{:?}: searching via multiline strategy", path);
         MultiLine::new(
             self,
@@ -249,6 +267,28 @@ impl Searcher {
             write_to,
         )
         .run()
+    }
+
+    fn search_file_maybe_path_callback<TError: SinkError>(
+        &mut self,
+        query_context: QueryContext,
+        path: Option<&Path>,
+        file: &File,
+        callback: impl Fn(Node, &[u8]),
+    ) -> Result<(), TError> {
+        if let Some(mmap) = self.config.mmap.open(file, path) {
+            log::trace!("{:?}: searching via memory map", path);
+            return self
+                .search_slice_callback(query_context, &mmap, callback)
+                .map_err(TError::error_config);
+        }
+        log::trace!("{:?}: reading entire file on to heap for mulitline", path);
+        self.fill_multi_line_buffer_from_file(file)
+            .map_err(TError::error_io)?;
+        log::trace!("{:?}: searching via multiline strategy", path);
+        self.run_with_callback(query_context, &self.multi_line_buffer.borrow(), callback);
+
+        Ok(())
     }
 
     #[allow(dead_code)]
@@ -271,7 +311,8 @@ impl Searcher {
             .map_err(S::Error::error_io)?;
 
         log::trace!("generic reader: reading everything to heap for multiline");
-        self.fill_multi_line_buffer_from_reader::<_, S>(decoder)?;
+        self.fill_multi_line_buffer_from_reader(decoder)
+            .map_err(S::Error::error_io)?;
         log::trace!("generic reader: searching via multiline strategy");
         MultiLine::new(
             self,
@@ -295,6 +336,58 @@ impl Searcher {
 
         log::trace!("slice reader: searching via multiline strategy");
         MultiLine::new(self, query_context, slice, write_to).run()
+    }
+
+    fn search_slice_callback(
+        &mut self,
+        query_context: QueryContext,
+        slice: &[u8],
+        callback: impl Fn(Node, &[u8]),
+    ) -> Result<(), ConfigError> {
+        self.check_config()?;
+
+        log::trace!("slice reader: searching via multiline strategy");
+        self.run_with_callback(query_context, slice, callback);
+
+        Ok(())
+    }
+
+    fn run_with_callback(
+        &self,
+        query_context: QueryContext,
+        slice: &[u8],
+        callback: impl Fn(Node, &[u8]),
+    ) {
+        let mut query_cursor = QueryCursor::new();
+        let tree = get_parser(query_context.language)
+            .parse(slice, None)
+            .unwrap();
+        let query = &query_context.query;
+        let capture_index = query_context.capture_index;
+        let filter = &query_context.filter;
+        query_cursor
+            .captures(query, tree.root_node(), slice)
+            .filter_map(|(match_, found_capture_index)| {
+                let found_capture_index = found_capture_index as u32;
+                if found_capture_index != capture_index {
+                    return None;
+                }
+                let mut nodes_for_this_capture = match_.nodes_for_capture_index(capture_index);
+                let single_captured_node = nodes_for_this_capture.next().unwrap();
+                assert!(
+                    nodes_for_this_capture.next().is_none(),
+                    "I guess .captures() always wraps up the single capture like this?"
+                );
+                match filter.as_ref() {
+                    None => Some(single_captured_node),
+                    Some(filter) => filter
+                        .call(&single_captured_node)
+                        .then_some(single_captured_node),
+                }
+            })
+            .for_each(|node| {
+                callback(node, slice);
+            });
     }
 
     fn check_config(&self) -> Result<(), ConfigError> {
@@ -340,44 +433,36 @@ impl Searcher {
         self.config.passthru
     }
 
-    fn fill_multi_line_buffer_from_file<S: Sink>(&self, file: &File) -> Result<(), S::Error> {
+    fn fill_multi_line_buffer_from_file(&self, file: &File) -> io::Result<()> {
         let mut decode_buffer = self.decode_buffer.borrow_mut();
         let mut read_from = self
             .decode_builder
-            .build_with_buffer(file, &mut *decode_buffer)
-            .map_err(S::Error::error_io)?;
+            .build_with_buffer(file, &mut *decode_buffer)?;
 
         if self.config.heap_limit.is_none() {
             let mut buf = self.multi_line_buffer.borrow_mut();
             buf.clear();
             let cap = file.metadata().map(|m| m.len() as usize + 1).unwrap_or(0);
             buf.reserve(cap);
-            read_from
-                .read_to_end(&mut buf)
-                .map_err(S::Error::error_io)?;
+            read_from.read_to_end(&mut buf)?;
             return Ok(());
         }
-        self.fill_multi_line_buffer_from_reader::<_, S>(read_from)
+        self.fill_multi_line_buffer_from_reader(read_from)
     }
 
-    fn fill_multi_line_buffer_from_reader<R: io::Read, S: Sink>(
-        &self,
-        mut read_from: R,
-    ) -> Result<(), S::Error> {
+    fn fill_multi_line_buffer_from_reader<R: io::Read>(&self, mut read_from: R) -> io::Result<()> {
         let mut buf = self.multi_line_buffer.borrow_mut();
         buf.clear();
 
         let heap_limit = match self.config.heap_limit {
             Some(heap_limit) => heap_limit,
             None => {
-                read_from
-                    .read_to_end(&mut buf)
-                    .map_err(S::Error::error_io)?;
+                read_from.read_to_end(&mut buf)?;
                 return Ok(());
             }
         };
         if heap_limit == 0 {
-            return Err(S::Error::error_io(alloc_error(heap_limit)));
+            return Err(alloc_error(heap_limit));
         }
 
         buf.resize(cmp::min(DEFAULT_BUFFER_CAPACITY, heap_limit), 0);
@@ -388,7 +473,7 @@ impl Searcher {
                 Err(ref err) if err.kind() == io::ErrorKind::Interrupted => {
                     continue;
                 }
-                Err(err) => return Err(S::Error::error_io(err)),
+                Err(err) => return Err(err),
             };
             if nread == 0 {
                 buf.resize(pos, 0);
@@ -399,7 +484,7 @@ impl Searcher {
             if buf[pos..].is_empty() {
                 let additional = heap_limit - buf.len();
                 if additional == 0 {
-                    return Err(S::Error::error_io(alloc_error(heap_limit)));
+                    return Err(alloc_error(heap_limit));
                 }
                 let limit = buf.len() + additional;
                 let doubled = 2 * buf.len();


### PR DESCRIPTION
In this PR:
- "proof-of-concept" of exposing a crate-level API that allows passing a callback that gets invoked for each matching tree-sitter AST node

Not in this PR:
- thinking about how to reasonably pass `Args`/configuration via a crate-level API
- tests
- docs for the crate-level API

To test:
Per the newly added example, you should be able to call the `tree_sitter::run_with_callback()` function (with a constructed `Args` instance) and do stuff in the provided callback that has access to the matched `tree_sitter::Node`, the file path where the match was found, and the source text for that file

Doing stuff via that crate-level API should be roughly as fast as via the command line (I assume)
(and performance via the command-line should still be about the same as what it was)

Based on `error-types`