### PR TITLE
WIP: show heading + color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ assert_cmd = "2.0.11"
 escargot = "0.5.7"
 predicates = "3.0.3"
 shlex = "1.1.0"
+text-diff = "0.4.0"
 
 [features]
 default = ["bytecount/runtime-dispatch-simd"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ bytecount = "0.6"
 clap = { version = "4.3.0", features = ["derive", "wrap_help"] }
 encoding_rs = "0.8.14"
 encoding_rs_io = "0.1.6"
+grep-cli = "0.1.8"
 ignore = { package = "tree_sitter_grep_ignore", git = "https://github.com/helixbass/ripgrep", rev = "669ebd3", version = "0.4.20-dev.0" }
 libc = "0.2.144"
 libloading = "0.8.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -199,7 +199,7 @@ pub struct Args {
     /// This is the default mode when not printing to a terminal.
     ///
     /// This overrides the --heading flag.
-    #[arg(long, hide = true, overrides_with = "heading")]
+    #[arg(long, overrides_with = "heading")]
     pub no_heading: bool,
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -21,9 +21,13 @@ use crate::{
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 pub enum ColorChoiceArg {
+    /// Colors will never be used.
     Never,
+    /// The default. tree-sitter-grep tries to be smart.
     Auto,
+    /// Colors will always be used regardless of where output is sent.
     Always,
+    /// Like 'always', but emits ANSI escapes (even in a Windows console).
     Ansi,
 }
 
@@ -116,70 +120,85 @@ pub struct Args {
     #[arg(short = 'b', long)]
     pub byte_offset: bool,
 
-    // This flag specifies color settings for use in the output.
-    //
-    // This flag may be provided multiple times. Settings are applied iteratively. Colors are
-    // limited to one of eight choices: red, blue, green, cyan, magenta, yellow, white and
-    // black. Styles are limited to nobold, bold, nointense, intense, nounderline
-    // or underline.
-    //
-    // The format of the flag is '{type}:{attribute}:{value}'. '{type}' should be
-    // one of path, line, column or match. '{attribute}' can be fg, bg or style.
-    // '{value}' is either a color (for fg and bg) or a text style. A special format,
-    // '{type}:none', will clear all color settings for '{type}'.
-    //
-    // For example, the following command will change the match color to magenta and
-    // the background color for line numbers to yellow:
-    //
-    //     tree-sitter-grep --colors 'match:fg:magenta' --colors 'line:bg:yellow' -q
-    // '(function_item) @f'
-    //
-    // Extended colors can be used for '{value}' when the terminal supports ANSI color
-    // sequences. These are specified as either 'x' (256-color) or 'x,x,x' (24-bit
-    // truecolor) where x is a number between 0 and 255 inclusive. x may be given as
-    // a normal decimal number or a hexadecimal number, which is prefixed by `0x`.
-    //
-    // For example, the following command will change the match background color to
-    // that represented by the rgb value (0,128,255):
-    //
-    //     tree-sitter-grep --colors 'match:bg:0,128,255'
-    //
-    // or, equivalently,
-    //
-    //     tree-sitter-grep --colors 'match:bg:0x0,0x80,0xFF'
-    //
-    // Note that the intense and nointense style flags will have no effect when
-    // used alongside these extended color codes.
+    /// This flag specifies color settings for use in the output.
+    ///
+    /// This flag may be provided multiple times. Settings are applied
+    /// iteratively. Colors are limited to one of eight choices: red, blue,
+    /// green, cyan, magenta, yellow, white and black. Styles are limited to
+    /// nobold, bold, nointense, intense, nounderline or underline.
+    ///
+    /// The format of the flag is '{type}:{attribute}:{value}'. '{type}' should
+    /// be one of path, line, column or match. '{attribute}' can be fg, bg
+    /// or style. '{value}' is either a color (for fg and bg) or a text
+    /// style. A special format, '{type}:none', will clear all color
+    /// settings for '{type}'.
+    ///
+    /// For example, the following command will change the match color to
+    /// magenta and the background color for line numbers to yellow:
+    ///
+    /// tree-sitter-grep --colors 'match:fg:magenta' --colors 'line:bg:yellow'
+    /// -q '(function_item) @f'
+    ///
+    /// Extended colors can be used for '{value}' when the terminal supports
+    /// ANSI color sequences. These are specified as either 'x' (256-color)
+    /// or 'x,x,x' (24-bit truecolor) where x is a number between 0 and 255
+    /// inclusive. x may be given as a normal decimal number or a
+    /// hexadecimal number, which is prefixed by `0x`.
+    ///
+    /// For example, the following command will change the match background
+    /// color to that represented by the rgb value (0,128,255):
+    ///
+    /// tree-sitter-grep --colors 'match:bg:0,128,255'
+    ///
+    /// or, equivalently,
+    ///
+    /// tree-sitter-grep --colors 'match:bg:0x0,0x80,0xFF'
+    ///
+    /// Note that the intense and nointense style flags will have no effect when
+    /// used alongside these extended color codes.
     #[arg(long)]
     pub colors: Vec<UserColorSpec>,
 
-    #[arg(long/*, default_value_t = ColorChoiceArg::Auto*/)]
+    /// This flag controls when to use colors.
+    ///
+    /// The default setting is 'auto', which means tree-sitter-grep will try to
+    /// guess when to use colors. For example, if tree-sitter-grep is printing
+    /// to a terminal, then it will use colors, but if it is redirected to a
+    /// file or a pipe, then it will suppress color output. tree-sitter-grep
+    /// will suppress color output in some other circumstances as well. For
+    /// example, if the TERM environment variable is not set or set to 'dumb',
+    /// then tree-sitter-grep will not use colors.
+    ///
+    /// When the --vimgrep flag is given to tree-sitter-grep, then the default
+    /// value for the --color flag changes to 'never'.
+    #[arg(long, value_name = "WHEN"/*, default_value_t = ColorChoiceArg::Auto*/)]
     pub color: Option<ColorChoiceArg>,
 
-    // This is a convenience alias for '--color always --heading --line-number'.
-    //
-    // This flag is useful when you still want pretty output even if you're piping tree-sitter-grep
-    // to another program or file. For example: 'tree-sitter-grep -p -q "(function_item) @c" | less
-    // -R'.
+    /// This is a convenience alias for '--color always --heading
+    /// --line-number'.
+    ///
+    /// This flag is useful when you still want pretty output even if you're
+    /// piping tree-sitter-grep to another program or file. For example:
+    /// 'tree-sitter-grep -p -q "(function_item) @c" | less -R'.
     #[arg(short = 'p', long)]
     pub pretty: bool,
 
-    // This flag prints the file path above clusters of matches from each file instead of printing
-    // the file path as a prefix for each matched line.
-    //
-    // This is the default mode when printing to a terminal.
-    //
-    // This overrides the --no-heading flag.
+    /// This flag prints the file path above clusters of matches from each file
+    /// instead of printing the file path as a prefix for each matched line.
+    ///
+    /// This is the default mode when printing to a terminal.
+    ///
+    /// This overrides the --no-heading flag.
     #[arg(long)]
     pub heading: bool,
 
-    // Don't group matches by each file.
-    //
-    // If --no-heading is provided in addition to the -H/--with-filename flag, then file paths will
-    // be printed as a prefix for every matched line. This is the default mode when not printing to
-    // a terminal.
-    //
-    // This overrides the --heading flag.
+    /// Don't group matches by each file.
+    ///
+    /// If --no-heading is provided in addition to the -H/--with-filename flag,
+    /// then file paths will be printed as a prefix for every matched line.
+    /// This is the default mode when not printing to a terminal.
+    ///
+    /// This overrides the --heading flag.
     #[arg(long, hide = true, overrides_with = "heading")]
     pub no_heading: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ use std::{
 use ignore::DirEntry;
 use plugin::get_loaded_filter;
 use rayon::prelude::*;
-use termcolor::{BufferWriter, ColorChoice};
 use thiserror::Error;
 use tree_sitter::{Query, QueryError};
 
@@ -273,7 +272,7 @@ pub fn run(args: Args) -> Result<RunStatus, Error> {
         get_loaded_filter(args.filter.as_deref(), args.filter_arg.as_deref())?.map(Arc::new);
     let cached_queries: CachedQueries = Default::default();
     let capture_index = CaptureIndex::default();
-    let buffer_writer = BufferWriter::stdout(ColorChoice::Never);
+    let buffer_writer = args.buffer_writer();
     let matched = AtomicBool::new(false);
     let searched = AtomicBool::new(false);
     let non_fatal_errors: Arc<Mutex<Vec<NonFatalError>>> = Default::default();

--- a/src/printer/color.rs
+++ b/src/printer/color.rs
@@ -4,16 +4,18 @@ use std::{error, fmt, str::FromStr};
 
 use termcolor::{Color, ColorSpec, ParseColorError};
 
-#[allow(dead_code)]
 pub fn default_color_specs() -> Vec<UserColorSpec> {
     vec![
         #[cfg(unix)]
-        "path:fg:magenta".parse().unwrap(),
+        "path:fg:green".parse().unwrap(),
         #[cfg(windows)]
         "path:fg:cyan".parse().unwrap(),
-        "line:fg:green".parse().unwrap(),
-        "match:fg:red".parse().unwrap(),
-        "match:style:bold".parse().unwrap(),
+        "path:style:bold".parse().unwrap(),
+        "line:fg:yellow".parse().unwrap(),
+        "line:style:bold".parse().unwrap(),
+        "match:fg:black".parse().unwrap(),
+        "match:bg:yellow".parse().unwrap(),
+        "match:style:nobold".parse().unwrap(),
     ]
 }
 

--- a/src/printer/mod.rs
+++ b/src/printer/mod.rs
@@ -4,4 +4,5 @@ mod standard;
 mod stats;
 mod util;
 
+pub use color::{default_color_specs, ColorError, ColorSpecs, UserColorSpec};
 pub use standard::{Standard, StandardBuilder};

--- a/src/use_printer.rs
+++ b/src/use_printer.rs
@@ -15,8 +15,14 @@ thread_local! {
 }
 pub(crate) fn get_printer(buffer_writer: &BufferWriter, args: &Args) -> Rc<RefCell<Printer>> {
     PRINTER.with(|printer| {
-        let (printer, args_when_initialized) =
-            printer.get_or_init(|| (Rc::new(RefCell::new(args.get_printer(buffer_writer))), args));
+        let (printer, args_when_initialized) = printer.get_or_init(|| {
+            (
+                Rc::new(RefCell::new(
+                    args.get_printer(&args.use_paths(), buffer_writer),
+                )),
+                args,
+            )
+        });
         assert!(
             ptr::eq(*args_when_initialized, args),
             "Using multiple instances of args not supported"

--- a/src/use_searcher.rs
+++ b/src/use_searcher.rs
@@ -11,8 +11,12 @@ thread_local! {
 }
 pub(crate) fn get_searcher(args: &Args) -> Rc<RefCell<Searcher>> {
     SEARCHER.with(|searcher| {
-        let (searcher, args_when_initialized) =
-            searcher.get_or_init(|| (Rc::new(RefCell::new(args.get_searcher())), args));
+        let (searcher, args_when_initialized) = searcher.get_or_init(|| {
+            (
+                Rc::new(RefCell::new(args.get_searcher(&args.use_paths()))),
+                args,
+            )
+        });
         assert!(
             ptr::eq(*args_when_initialized, args),
             "Using multiple instances of args not supported"

--- a/tests/languages.rs
+++ b/tests/languages.rs
@@ -8,7 +8,7 @@ fn test_swift() {
         "swift_project",
         r#"
             $ tree-sitter-grep -q '(value_argument) @c' --language swift
-            example.swift:2:    atPath: "native"
+            example.swift:    atPath: "native"
         "#,
     );
 }
@@ -19,7 +19,7 @@ fn test_swift_auto_language() {
         "swift_project",
         r#"
             $ tree-sitter-grep -q '(value_argument) @c'
-            example.swift:2:    atPath: "native"
+            example.swift:    atPath: "native"
         "#,
     );
 }
@@ -30,7 +30,7 @@ fn test_objective_c() {
         "objective_c_project",
         r#"
             $ tree-sitter-grep -q '(struct_declaration) @c' --language objective-c
-            example.h:4:@property (nonatomic, strong, nullable) NSString *baseURL;
+            example.h:@property (nonatomic, strong, nullable) NSString *baseURL;
         "#,
     );
 }
@@ -41,7 +41,7 @@ fn test_objective_c_auto_language() {
         "objective_c_project",
         r#"
             $ tree-sitter-grep -q '(struct_declaration) @c'
-            example.h:4:@property (nonatomic, strong, nullable) NSString *baseURL;
+            example.h:@property (nonatomic, strong, nullable) NSString *baseURL;
         "#,
     );
 }
@@ -63,9 +63,9 @@ fn test_toml() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(string) @c' --language toml
-            Cargo.toml:2:name = "rust_project"
-            Cargo.toml:3:version = "0.1.0"
-            Cargo.toml:4:edition = "2021"
+            Cargo.toml:name = "rust_project"
+            Cargo.toml:version = "0.1.0"
+            Cargo.toml:edition = "2021"
         "#,
     );
 }
@@ -76,9 +76,9 @@ fn test_toml_auto_language() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(string) @c'
-            Cargo.toml:2:name = "rust_project"
-            Cargo.toml:3:version = "0.1.0"
-            Cargo.toml:4:edition = "2021"
+            Cargo.toml:name = "rust_project"
+            Cargo.toml:version = "0.1.0"
+            Cargo.toml:edition = "2021"
         "#,
     );
 }
@@ -89,8 +89,8 @@ fn test_python() {
         "python_project",
         r#"
             $ tree-sitter-grep -q '(for_statement) @c' --language python
-            example.py:2:    for x in y:
-            example.py:3:        something()
+            example.py:    for x in y:
+            example.py:        something()
         "#,
     );
 }
@@ -101,8 +101,8 @@ fn test_python_auto_language() {
         "python_project",
         r#"
             $ tree-sitter-grep -q '(for_statement) @c'
-            example.py:2:    for x in y:
-            example.py:3:        something()
+            example.py:    for x in y:
+            example.py:        something()
         "#,
     );
 }
@@ -113,7 +113,7 @@ fn test_ruby() {
         "ruby_project",
         r#"
             $ tree-sitter-grep -q '(binary) @c' --language ruby
-            example.rb:1:if x > y
+            example.rb:if x > y
         "#,
     );
 }
@@ -124,7 +124,7 @@ fn test_ruby_auto_language() {
         "ruby_project",
         r#"
             $ tree-sitter-grep -q '(binary) @c'
-            example.rb:1:if x > y
+            example.rb:if x > y
         "#,
     );
 }
@@ -135,7 +135,7 @@ fn test_c() {
         "c_project",
         r#"
             $ tree-sitter-grep -q '(pointer_declarator) @c' --language c
-            example.h:1:void r_bin_object_free(void /*RBinObject*/ *o_);
+            example.h:void r_bin_object_free(void /*RBinObject*/ *o_);
         "#,
     );
 }
@@ -157,7 +157,7 @@ fn test_cpp() {
         "cpp_project",
         r#"
             $ tree-sitter-grep -q '(namespace_identifier) @c' --language c++
-            example.cpp:1:const AvailableAttr *DeclAttributes::getUnavailable(
+            example.cpp:const AvailableAttr *DeclAttributes::getUnavailable(
         "#,
     );
 }
@@ -168,7 +168,7 @@ fn test_cpp_auto_language() {
         "cpp_project",
         r#"
             $ tree-sitter-grep -q '(namespace_identifier) @c'
-            example.cpp:1:const AvailableAttr *DeclAttributes::getUnavailable(
+            example.cpp:const AvailableAttr *DeclAttributes::getUnavailable(
         "#,
     );
 }
@@ -179,7 +179,7 @@ fn test_go() {
         "go_project",
         r#"
             $ tree-sitter-grep -q '(import_spec) @c' --language go
-            example.go:2:        "context"
+            example.go:        "context"
         "#,
     );
 }
@@ -190,7 +190,7 @@ fn test_go_auto_language() {
         "go_project",
         r#"
             $ tree-sitter-grep -q '(import_spec) @c'
-            example.go:2:        "context"
+            example.go:        "context"
         "#,
     );
 }
@@ -201,7 +201,7 @@ fn test_java() {
         "java_project",
         r#"
             $ tree-sitter-grep -q '(marker_annotation) @c' --language java
-            example.java:1:@ThreadSafe
+            example.java:@ThreadSafe
         "#,
     );
 }
@@ -212,7 +212,7 @@ fn test_java_auto_language() {
         "java_project",
         r#"
             $ tree-sitter-grep -q '(marker_annotation) @c'
-            example.java:1:@ThreadSafe
+            example.java:@ThreadSafe
         "#,
     );
 }
@@ -223,7 +223,7 @@ fn test_c_sharp() {
         "csharp_project",
         r#"
             $ tree-sitter-grep -q '(qualified_name) @c' --language c-sharp
-            example.cs:1:namespace YL.Utils.Json {}
+            example.cs:namespace YL.Utils.Json {}
         "#,
     );
 }
@@ -234,7 +234,7 @@ fn test_c_sharp_auto_language() {
         "csharp_project",
         r#"
             $ tree-sitter-grep -q '(qualified_name) @c'
-            example.cs:1:namespace YL.Utils.Json {}
+            example.cs:namespace YL.Utils.Json {}
         "#,
     );
 }
@@ -245,7 +245,7 @@ fn test_kotlin() {
         "kotlin_project",
         r#"
             $ tree-sitter-grep -q '(user_type) @c' --language kotlin
-            example.kt:2:    val barA: Int
+            example.kt:    val barA: Int
         "#,
     );
 }
@@ -256,7 +256,7 @@ fn test_kotlin_auto_language() {
         "kotlin_project",
         r#"
             $ tree-sitter-grep -q '(user_type) @c'
-            example.kt:2:    val barA: Int
+            example.kt:    val barA: Int
         "#,
     );
 }
@@ -267,8 +267,8 @@ fn test_elisp() {
         "elisp_project",
         r#"
             $ tree-sitter-grep -q '(quote) @c' --language elisp
-            example.el:3:  :group 'lsp-sourcekit
-            example.el:4:  :type 'file)
+            example.el:  :group 'lsp-sourcekit
+            example.el:  :type 'file)
         "#,
     );
 }
@@ -279,8 +279,8 @@ fn test_elisp_auto_language() {
         "elisp_project",
         r#"
             $ tree-sitter-grep -q '(quote) @c'
-            example.el:3:  :group 'lsp-sourcekit
-            example.el:4:  :type 'file)
+            example.el:  :group 'lsp-sourcekit
+            example.el:  :type 'file)
         "#,
     );
 }
@@ -291,7 +291,7 @@ fn test_elm() {
         "elm_project",
         r#"
             $ tree-sitter-grep -q '(upper_case_qid) @c' --language elm
-            example.elm:1:import Lofi.Schema exposing (Schema, Item, Kind(..))
+            example.elm:import Lofi.Schema exposing (Schema, Item, Kind(..))
         "#,
     );
 }
@@ -302,7 +302,7 @@ fn test_elm_auto_language() {
         "elm_project",
         r#"
             $ tree-sitter-grep -q '(upper_case_qid) @c'
-            example.elm:1:import Lofi.Schema exposing (Schema, Item, Kind(..))
+            example.elm:import Lofi.Schema exposing (Schema, Item, Kind(..))
         "#,
     );
 }
@@ -313,7 +313,7 @@ fn test_dockerfile() {
         "dockerfile_project",
         r#"
             $ tree-sitter-grep -q '(path) @c' --language dockerfile
-            Dockerfile:1:WORKDIR /usr/src/app
+            Dockerfile:WORKDIR /usr/src/app
         "#,
     );
 }
@@ -324,7 +324,7 @@ fn test_dockerfile_auto_language() {
         "dockerfile_project",
         r#"
             $ tree-sitter-grep -q '(path) @c'
-            Dockerfile:1:WORKDIR /usr/src/app
+            Dockerfile:WORKDIR /usr/src/app
         "#,
     );
 }
@@ -335,7 +335,7 @@ fn test_html() {
         "html_project",
         r#"
             $ tree-sitter-grep -q '(text) @c' --language html
-            example.html:3:    <p>hello</p>
+            example.html:    <p>hello</p>
         "#,
     );
 }
@@ -346,7 +346,7 @@ fn test_html_auto_language() {
         "html_project",
         r#"
             $ tree-sitter-grep -q '(text) @c'
-            example.html:3:    <p>hello</p>
+            example.html:    <p>hello</p>
         "#,
     );
 }
@@ -357,7 +357,7 @@ fn test_tree_sitter_query() {
         "tree_sitter_query_project",
         r#"
             $ tree-sitter-grep -q '(capture) @c' --language tree-sitter-query
-            example.scm:1:(function_item) @f
+            example.scm:(function_item) @f
         "#,
     );
 }
@@ -368,7 +368,7 @@ fn test_tree_sitter_query_auto_language() {
         "tree_sitter_query_project",
         r#"
             $ tree-sitter-grep -q '(capture) @c'
-            example.scm:1:(function_item) @f
+            example.scm:(function_item) @f
         "#,
     );
 }
@@ -379,7 +379,7 @@ fn test_json() {
         "json_project",
         r#"
             $ tree-sitter-grep -q '(string_content) @c' --language json
-            example.json:2:  "hello": "ok"
+            example.json:  "hello": "ok"
         "#,
     );
 }
@@ -390,7 +390,7 @@ fn test_json_auto_language() {
         "json_project",
         r#"
             $ tree-sitter-grep -q '(string_content) @c'
-            example.json:2:  "hello": "ok"
+            example.json:  "hello": "ok"
         "#,
     );
 }
@@ -401,7 +401,7 @@ fn test_css() {
         "css_project",
         r#"
             $ tree-sitter-grep -q '(tag_name) @c' --language css
-            example.css:1:h1 {
+            example.css:h1 {
         "#,
     );
 }
@@ -412,7 +412,7 @@ fn test_css_auto_language() {
         "css_project",
         r#"
             $ tree-sitter-grep -q '(tag_name) @c'
-            example.css:1:h1 {
+            example.css:h1 {
         "#,
     );
 }
@@ -423,7 +423,7 @@ fn test_lua() {
         "lua_project",
         r#"
             $ tree-sitter-grep -q '(identifier) @c' --language lua
-            example.lua:1:function hello()
+            example.lua:function hello()
         "#,
     );
 }
@@ -434,7 +434,7 @@ fn test_lua_auto_language() {
         "lua_project",
         r#"
             $ tree-sitter-grep -q '(identifier) @c'
-            example.lua:1:function hello()
+            example.lua:function hello()
         "#,
     );
 }

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -559,6 +559,15 @@ fn test_help_option() {
 
                       This overrides the --no-heading flag.
 
+                  --no-heading
+                      Don't group matches by each file.
+
+                      If --no-heading is provided in addition to the -H/--with-filename flag, then file paths
+                      will be printed as a prefix for every matched line. This is the default mode when not
+                      printing to a terminal.
+
+                      This overrides the --heading flag.
+
               -h, --help
                       Print help (see a summary with '-h')
         "#,
@@ -614,6 +623,8 @@ fn test_help_short_option() {
                   --heading
                       This flag prints the file path above clusters of matches from each file instead of
                       printing the file path as a prefix for each matched line
+                  --no-heading
+                      Don't group matches by each file
               -h, --help
                       Print help (see more with '--help')
         "#,

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -11,15 +11,15 @@ fn test_query_inline() {
         "rust_project",
         r#"
             $ tree-sitter-grep --query '(function_item) @function_item' --language rust
-            src/helpers.rs:1:pub fn helper() {}
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
-            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:pub fn helper() {}
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
+            src/stop.rs:fn stop_it() {}
         "#,
     );
 }
@@ -30,15 +30,15 @@ fn test_query_inline_short_option() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(function_item) @function_item' --language rust
-            src/helpers.rs:1:pub fn helper() {}
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
-            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:pub fn helper() {}
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
+            src/stop.rs:fn stop_it() {}
         "#,
     );
 }
@@ -63,15 +63,15 @@ fn test_query_file() {
         "rust_project",
         r#"
             $ tree-sitter-grep --query-file ./function-item.scm --language rust
-            src/helpers.rs:1:pub fn helper() {}
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
-            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:pub fn helper() {}
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
+            src/stop.rs:fn stop_it() {}
        "#,
     );
 }
@@ -82,15 +82,15 @@ fn test_query_file_short_option() {
         "rust_project",
         r#"
             $ tree-sitter-grep -Q ./function-item.scm --language rust
-            src/helpers.rs:1:pub fn helper() {}
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
-            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:pub fn helper() {}
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
+            src/stop.rs:fn stop_it() {}
        "#,
     );
 }
@@ -101,13 +101,13 @@ fn test_specify_single_file() {
         "rust_project",
         r#"
             $ tree-sitter-grep --query '(function_item) @function_item' --language rust src/lib.rs
-            3:pub fn add(left: usize, right: usize) -> usize {
-            4:    left + right
-            5:}
-            12:    fn it_works() {
-            13:        let result = add(2, 2);
-            14:        assert_eq!(result, 4);
-            15:    }
+            pub fn add(left: usize, right: usize) -> usize {
+                left + right
+            }
+                fn it_works() {
+                    let result = add(2, 2);
+                    assert_eq!(result, 4);
+                }
         "#,
     );
 }
@@ -118,13 +118,13 @@ fn test_specify_single_file_preserves_leading_dot_slash() {
         "rust_project",
         r#"
             $ tree-sitter-grep --query '(function_item) @function_item' --language rust --with-filename ./src/lib.rs
-            ./src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            ./src/lib.rs:4:    left + right
-            ./src/lib.rs:5:}
-            ./src/lib.rs:12:    fn it_works() {
-            ./src/lib.rs:13:        let result = add(2, 2);
-            ./src/lib.rs:14:        assert_eq!(result, 4);
-            ./src/lib.rs:15:    }
+            ./src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            ./src/lib.rs:    left + right
+            ./src/lib.rs:}
+            ./src/lib.rs:    fn it_works() {
+            ./src/lib.rs:        let result = add(2, 2);
+            ./src/lib.rs:        assert_eq!(result, 4);
+            ./src/lib.rs:    }
         "#,
     );
 }
@@ -135,14 +135,14 @@ fn test_specify_multiple_files() {
         "rust_project",
         r#"
             $ tree-sitter-grep --query '(function_item) @function_item' --language rust src/lib.rs ./src/helpers.rs
-            ./src/helpers.rs:1:pub fn helper() {}
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
+            ./src/helpers.rs:pub fn helper() {}
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
         "#,
     );
 }
@@ -218,15 +218,15 @@ fn test_auto_language_single_known_language_encountered() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(function_item) @function_item'
-            src/helpers.rs:1:pub fn helper() {}
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
-            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:pub fn helper() {}
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
+            src/stop.rs:fn stop_it() {}
         "#,
     );
 }
@@ -237,8 +237,8 @@ fn test_auto_language_multiple_parseable_languages() {
         "mixed_project",
         r#"
             $ tree-sitter-grep -q '(arrow_function) @arrow_function'
-            javascript_src/index.js:1:const js_foo = () => {}
-            typescript_src/index.tsx:1:const foo = () => {}
+            javascript_src/index.js:const js_foo = () => {}
+            typescript_src/index.tsx:const foo = () => {}
         "#,
     );
 }
@@ -249,7 +249,7 @@ fn test_auto_language_single_parseable_languages() {
         "mixed_project",
         r#"
             $ tree-sitter-grep -q '(function_item) @function_item'
-            rust_src/lib.rs:1:fn foo() {}
+            rust_src/lib.rs:fn foo() {}
         "#,
     );
 }
@@ -260,15 +260,15 @@ fn test_capture_name() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(function_item name: (identifier) @name) @function_item' --language rust --capture function_item
-            src/helpers.rs:1:pub fn helper() {}
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
-            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:pub fn helper() {}
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
+            src/stop.rs:fn stop_it() {}
         "#,
     );
 }
@@ -279,9 +279,9 @@ fn test_predicate() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(function_item name: (identifier) @name (#eq? @name "add")) @function_item' --language rust --capture function_item
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
         "#,
     );
 }
@@ -317,7 +317,7 @@ fn test_unknown_option() {
 
               tip: a similar argument exists: '--query'
 
-            Usage: tree-sitter-grep <--query-file <PATH_TO_QUERY_FILE>|--query <QUERY_TEXT>|--filter <PATH_TO_FILTER_PLUGIN_DYNAMIC_LIBRARY>> <PATHS|--query-file <PATH_TO_QUERY_FILE>|--query <QUERY_TEXT>|--capture <CAPTURE_NAME>|--language <LANGUAGE>|--filter <PATH_TO_FILTER_PLUGIN_DYNAMIC_LIBRARY>|--filter-arg <FILTER_ARG>|--vimgrep|--after-context <NUM>|--before-context <NUM>|--context <NUM>|--only-matching|--byte-offset|--colors <COLORS>|--color <WHEN>|--pretty|--heading|--no-heading|--with-filename|--no-filename>
+            Usage: tree-sitter-grep <--query-file <PATH_TO_QUERY_FILE>|--query <QUERY_TEXT>|--filter <PATH_TO_FILTER_PLUGIN_DYNAMIC_LIBRARY>> <PATHS|--query-file <PATH_TO_QUERY_FILE>|--query <QUERY_TEXT>|--capture <CAPTURE_NAME>|--language <LANGUAGE>|--filter <PATH_TO_FILTER_PLUGIN_DYNAMIC_LIBRARY>|--filter-arg <FILTER_ARG>|--vimgrep|--after-context <NUM>|--before-context <NUM>|--context <NUM>|--only-matching|--byte-offset|--colors <COLORS>|--color <WHEN>|--pretty|--heading|--no-heading|--with-filename|--no-filename|--line-number|--no-line-number|--column|--no-column>
 
             For more information, try '--help'.
         "#,
@@ -332,11 +332,11 @@ fn test_filter_plugin() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(function_item) @function_item' --language rust --filter ../../../target/debug/examples/libfilter_before_line_10.so
-            src/helpers.rs:1:pub fn helper() {}
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:pub fn helper() {}
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/stop.rs:fn stop_it() {}
         "#,
     );
 }
@@ -349,8 +349,8 @@ fn test_filter_plugin_with_argument() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(function_item) @function_item' --language rust --filter ../../../target/debug/examples/libfilter_before_line_number.so --filter-arg 2
-            src/helpers.rs:1:pub fn helper() {}
-            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:pub fn helper() {}
+            src/stop.rs:fn stop_it() {}
         "#,
     );
 }
@@ -389,11 +389,11 @@ fn test_filter_plugin_no_query() {
         "rust_project",
         r#"
             $ tree-sitter-grep --language rust --filter ../../../target/debug/examples/libfilter_function_items_before_line_10.so
-            src/helpers.rs:1:pub fn helper() {}
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/stop.rs:1:fn stop_it() {}
+            src/helpers.rs:pub fn helper() {}
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/stop.rs:fn stop_it() {}
         "#,
     );
 }
@@ -586,6 +586,24 @@ fn test_help_option() {
 
                       This flag overrides --with-filename.
 
+              -n, --line-number
+                      Show line numbers (1-based).
+
+                      This is enabled by default when searching in a terminal.
+
+              -N, --no-line-number
+                      Suppress line numbers.
+
+                      This is enabled by default when not searching in a terminal.
+
+                  --column
+                      Show column numbers (1-based).
+
+                      This only shows the column numbers for the first match on each line. This does not try to
+                      account for Unicode. One byte is equal to one column. This implies --line-number.
+
+                      This flag can be disabled with --no-column.
+
               -h, --help
                       Print help (see a summary with '-h')
         "#,
@@ -647,6 +665,12 @@ fn test_help_short_option() {
                       Display the file path for matches
               -I, --no-filename
                       Never print the file path with the matched lines
+              -n, --line-number
+                      Show line numbers (1-based)
+              -N, --no-line-number
+                      Suppress line numbers
+                  --column
+                      Show column numbers (1-based)
               -h, --help
                       Print help (see more with '--help')
         "#,
@@ -693,9 +717,9 @@ fn test_macro_contents() {
         "match_inside_macro",
         r#"
             $ tree-sitter-grep -q '(call_expression) @c' -l rust
-            foo.rs:4:        self.factory
-            foo.rs:5:            .create_parameter_declaration("whee", Option::<Gc<NodeArray>>::None)
-            foo.rs:6:            .wrap(),
+            foo.rs:        self.factory
+            foo.rs:            .create_parameter_declaration("whee", Option::<Gc<NodeArray>>::None)
+            foo.rs:            .wrap(),
         "#,
     );
 }
@@ -718,11 +742,11 @@ fn test_overlapping_matches() {
         "rust_overlapping",
         r#"
             $ tree-sitter-grep -q '(closure_expression) @closure_expression' --language rust
-            src/lib.rs:2:    let f = || {
-            src/lib.rs:3:        || {
-            src/lib.rs:4:            println!("whee");
-            src/lib.rs:5:        }
-            src/lib.rs:6:    };
+            src/lib.rs:    let f = || {
+            src/lib.rs:        || {
+            src/lib.rs:            println!("whee");
+            src/lib.rs:        }
+            src/lib.rs:    };
         "#,
     );
 }
@@ -745,22 +769,22 @@ fn test_after_context() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(function_item) @f' -l rust --after-context 2
-            src/stop.rs:1:fn stop_it() {}
+            src/stop.rs:fn stop_it() {}
             --
-            src/helpers.rs:1:pub fn helper() {}
+            src/helpers.rs:pub fn helper() {}
             --
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/lib.rs-6-
-            src/lib.rs-7-#[cfg(test)]
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/lib.rs-
+            src/lib.rs-#[cfg(test)]
             --
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
-            src/lib.rs-16-}
-            src/lib.rs-17-
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
+            src/lib.rs-}
+            src/lib.rs-
         "#,
     );
 }
@@ -771,10 +795,10 @@ fn test_after_context_matches_overlap_context_lines() {
         "rust_overlapping",
         r#"
             $ tree-sitter-grep -q '(call_expression function: (identifier) @function_name (#match? @function_name "^h"))' -l rust -A 2
-            src/lib.rs:10:    hello();
-            src/lib.rs:11:    hoo();
-            src/lib.rs-12-    raa();
-            src/lib.rs-13-    roo();
+            src/lib.rs:    hello();
+            src/lib.rs:    hoo();
+            src/lib.rs-    raa();
+            src/lib.rs-    roo();
         "#,
     );
 }
@@ -785,13 +809,13 @@ fn test_after_context_overlapping_matches() {
         "rust_overlapping",
         r#"
             $ tree-sitter-grep -q '(closure_expression) @c' -l rust --after-context 2
-            src/lib.rs:2:    let f = || {
-            src/lib.rs:3:        || {
-            src/lib.rs:4:            println!("whee");
-            src/lib.rs:5:        }
-            src/lib.rs:6:    };
-            src/lib.rs-7-}
-            src/lib.rs-8-
+            src/lib.rs:    let f = || {
+            src/lib.rs:        || {
+            src/lib.rs:            println!("whee");
+            src/lib.rs:        }
+            src/lib.rs:    };
+            src/lib.rs-}
+            src/lib.rs-
         "#,
     );
 }
@@ -816,22 +840,22 @@ fn test_after_context_short_option() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(function_item) @f' -l rust -A 2
-            src/stop.rs:1:fn stop_it() {}
+            src/stop.rs:fn stop_it() {}
             --
-            src/helpers.rs:1:pub fn helper() {}
+            src/helpers.rs:pub fn helper() {}
             --
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/lib.rs-6-
-            src/lib.rs-7-#[cfg(test)]
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/lib.rs-
+            src/lib.rs-#[cfg(test)]
             --
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
-            src/lib.rs-16-}
-            src/lib.rs-17-
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
+            src/lib.rs-}
+            src/lib.rs-
         "#,
     );
 }
@@ -842,23 +866,23 @@ fn test_before_context() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(function_item) @f' -l rust --before-context 3
-            src/stop.rs:1:fn stop_it() {}
+            src/stop.rs:fn stop_it() {}
             --
-            src/helpers.rs:1:pub fn helper() {}
+            src/helpers.rs:pub fn helper() {}
             --
-            src/lib.rs-1-mod helpers;
-            src/lib.rs-2-
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
+            src/lib.rs-mod helpers;
+            src/lib.rs-
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
             --
-            src/lib.rs-9-    use super::*;
-            src/lib.rs-10-
-            src/lib.rs-11-    #[test]
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
+            src/lib.rs-    use super::*;
+            src/lib.rs-
+            src/lib.rs-    #[test]
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
         "#,
     );
 }
@@ -869,23 +893,23 @@ fn test_before_context_short_option() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(function_item) @f' -l rust -B 3
-            src/stop.rs:1:fn stop_it() {}
+            src/stop.rs:fn stop_it() {}
             --
-            src/helpers.rs:1:pub fn helper() {}
+            src/helpers.rs:pub fn helper() {}
             --
-            src/lib.rs-1-mod helpers;
-            src/lib.rs-2-
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
+            src/lib.rs-mod helpers;
+            src/lib.rs-
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
             --
-            src/lib.rs-9-    use super::*;
-            src/lib.rs-10-
-            src/lib.rs-11-    #[test]
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
+            src/lib.rs-    use super::*;
+            src/lib.rs-
+            src/lib.rs-    #[test]
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
         "#,
     );
 }
@@ -896,10 +920,10 @@ fn test_before_context_matches_overlap_context_lines() {
         "rust_overlapping",
         r#"
             $ tree-sitter-grep -q '(call_expression function: (identifier) @function_name (#match? @function_name "^h"))' -l rust -B 2
-            src/lib.rs-8-
-            src/lib.rs-9-fn something_else() {
-            src/lib.rs:10:    hello();
-            src/lib.rs:11:    hoo();
+            src/lib.rs-
+            src/lib.rs-fn something_else() {
+            src/lib.rs:    hello();
+            src/lib.rs:    hoo();
         "#,
     );
 }
@@ -910,13 +934,13 @@ fn test_before_context_overlapping_matches() {
         "rust_overlapping_with_preceding_lines",
         r#"
             $ tree-sitter-grep -q '(closure_expression) @c' -l rust --before-context 2
-            src/lib.rs-5-        .i_promise()
-            src/lib.rs-6-        .but_it_has_to_be_longer();
-            src/lib.rs:7:    let f = || {
-            src/lib.rs:8:        || {
-            src/lib.rs:9:            println!("whee");
-            src/lib.rs:10:        }
-            src/lib.rs:11:    };
+            src/lib.rs-        .i_promise()
+            src/lib.rs-        .but_it_has_to_be_longer();
+            src/lib.rs:    let f = || {
+            src/lib.rs:        || {
+            src/lib.rs:            println!("whee");
+            src/lib.rs:        }
+            src/lib.rs:    };
         "#,
     );
 }
@@ -941,26 +965,26 @@ fn test_context() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(function_item) @f' -l rust --context 2
-            src/stop.rs:1:fn stop_it() {}
+            src/stop.rs:fn stop_it() {}
             --
-            src/helpers.rs:1:pub fn helper() {}
+            src/helpers.rs:pub fn helper() {}
             --
-            src/lib.rs-1-mod helpers;
-            src/lib.rs-2-
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/lib.rs-6-
-            src/lib.rs-7-#[cfg(test)]
+            src/lib.rs-mod helpers;
+            src/lib.rs-
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/lib.rs-
+            src/lib.rs-#[cfg(test)]
             --
-            src/lib.rs-10-
-            src/lib.rs-11-    #[test]
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
-            src/lib.rs-16-}
-            src/lib.rs-17-
+            src/lib.rs-
+            src/lib.rs-    #[test]
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
+            src/lib.rs-}
+            src/lib.rs-
         "#,
     );
 }
@@ -971,28 +995,28 @@ fn test_context_adjacent_after_and_before_context_lines() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(function_item) @f' -l rust --context 3
-            src/stop.rs:1:fn stop_it() {}
+            src/stop.rs:fn stop_it() {}
             --
-            src/helpers.rs:1:pub fn helper() {}
+            src/helpers.rs:pub fn helper() {}
             --
-            src/lib.rs-1-mod helpers;
-            src/lib.rs-2-
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/lib.rs-6-
-            src/lib.rs-7-#[cfg(test)]
-            src/lib.rs-8-mod tests {
-            src/lib.rs-9-    use super::*;
-            src/lib.rs-10-
-            src/lib.rs-11-    #[test]
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
-            src/lib.rs-16-}
-            src/lib.rs-17-
-            src/lib.rs-18-mod stop;
+            src/lib.rs-mod helpers;
+            src/lib.rs-
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/lib.rs-
+            src/lib.rs-#[cfg(test)]
+            src/lib.rs-mod tests {
+            src/lib.rs-    use super::*;
+            src/lib.rs-
+            src/lib.rs-    #[test]
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
+            src/lib.rs-}
+            src/lib.rs-
+            src/lib.rs-mod stop;
         "#,
     );
 }
@@ -1003,28 +1027,28 @@ fn test_context_overlapping_after_and_before_context_lines() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(function_item) @f' -l rust --context 4
-            src/stop.rs:1:fn stop_it() {}
+            src/stop.rs:fn stop_it() {}
             --
-            src/helpers.rs:1:pub fn helper() {}
+            src/helpers.rs:pub fn helper() {}
             --
-            src/lib.rs-1-mod helpers;
-            src/lib.rs-2-
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/lib.rs-6-
-            src/lib.rs-7-#[cfg(test)]
-            src/lib.rs-8-mod tests {
-            src/lib.rs-9-    use super::*;
-            src/lib.rs-10-
-            src/lib.rs-11-    #[test]
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
-            src/lib.rs-16-}
-            src/lib.rs-17-
-            src/lib.rs-18-mod stop;
+            src/lib.rs-mod helpers;
+            src/lib.rs-
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/lib.rs-
+            src/lib.rs-#[cfg(test)]
+            src/lib.rs-mod tests {
+            src/lib.rs-    use super::*;
+            src/lib.rs-
+            src/lib.rs-    #[test]
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
+            src/lib.rs-}
+            src/lib.rs-
+            src/lib.rs-mod stop;
         "#,
     );
 }
@@ -1035,26 +1059,26 @@ fn test_context_short_option() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(function_item) @f' -l rust -C 2
-            src/stop.rs:1:fn stop_it() {}
+            src/stop.rs:fn stop_it() {}
             --
-            src/helpers.rs:1:pub fn helper() {}
+            src/helpers.rs:pub fn helper() {}
             --
-            src/lib.rs-1-mod helpers;
-            src/lib.rs-2-
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/lib.rs-6-
-            src/lib.rs-7-#[cfg(test)]
+            src/lib.rs-mod helpers;
+            src/lib.rs-
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/lib.rs-
+            src/lib.rs-#[cfg(test)]
             --
-            src/lib.rs-10-
-            src/lib.rs-11-    #[test]
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
-            src/lib.rs-16-}
-            src/lib.rs-17-
+            src/lib.rs-
+            src/lib.rs-    #[test]
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
+            src/lib.rs-}
+            src/lib.rs-
         "#,
     );
 }
@@ -1065,24 +1089,24 @@ fn test_before_and_after_context() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(function_item) @f' -l rust --before-context 2 --after-context 1
-            src/stop.rs:1:fn stop_it() {}
+            src/stop.rs:fn stop_it() {}
             --
-            src/helpers.rs:1:pub fn helper() {}
+            src/helpers.rs:pub fn helper() {}
             --
-            src/lib.rs-1-mod helpers;
-            src/lib.rs-2-
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/lib.rs-6-
+            src/lib.rs-mod helpers;
+            src/lib.rs-
+            src/lib.rs:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:    left + right
+            src/lib.rs:}
+            src/lib.rs-
             --
-            src/lib.rs-10-
-            src/lib.rs-11-    #[test]
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
-            src/lib.rs-16-}
+            src/lib.rs-
+            src/lib.rs-    #[test]
+            src/lib.rs:    fn it_works() {
+            src/lib.rs:        let result = add(2, 2);
+            src/lib.rs:        assert_eq!(result, 4);
+            src/lib.rs:    }
+            src/lib.rs-}
         "#,
     );
 }
@@ -1203,8 +1227,8 @@ fn test_only_matching() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(parameter) @c' --language rust --only-matching
-            src/lib.rs:3:left: usize
-            src/lib.rs:3:right: usize
+            src/lib.rs:left: usize
+            src/lib.rs:right: usize
         "#,
     );
 }
@@ -1215,8 +1239,8 @@ fn test_only_matching_short_option() {
         "rust_project",
         r#"
             $ tree-sitter-grep -q '(parameter) @c' --language rust -o
-            src/lib.rs:3:left: usize
-            src/lib.rs:3:right: usize
+            src/lib.rs:left: usize
+            src/lib.rs:right: usize
         "#,
     );
 }
@@ -1227,11 +1251,11 @@ fn test_only_matching_multiline_overlapping_matches() {
         "rust_overlapping",
         r#"
             $ tree-sitter-grep -q '(closure_expression) @c' -l rust --only-matching
-            src/lib.rs:2:|| {
-            src/lib.rs:3:        || {
-            src/lib.rs:4:            println!("whee");
-            src/lib.rs:5:        }
-            src/lib.rs:6:    }
+            src/lib.rs:|| {
+            src/lib.rs:        || {
+            src/lib.rs:            println!("whee");
+            src/lib.rs:        }
+            src/lib.rs:    }
         "#,
     );
 }
@@ -1242,10 +1266,10 @@ fn test_only_matching_multiline_overlapping_matches_starting_on_same_line() {
         "rust_overlapping_start_same_line",
         r#"
             $ tree-sitter-grep -q '(closure_expression) @c' -l rust --only-matching
-            src/lib.rs:3:|| { || {
-            src/lib.rs:4:            println!("whee");
-            src/lib.rs:5:        }
-            src/lib.rs:6:    }
+            src/lib.rs:|| { || {
+            src/lib.rs:            println!("whee");
+            src/lib.rs:        }
+            src/lib.rs:    }
         "#,
     );
 }
@@ -1267,15 +1291,15 @@ fn test_byte_offset() {
         "rust_project_byte_offset",
         r#"
             $ tree-sitter-grep -q '(function_item) @function_item' -l rust --byte-offset
-            src/helpers.rs:1:0:pub fn helper() {}
-            src/stop.rs:1:0:fn stop_it() {}
-            src/lib.rs:3:14:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:63:    left + right
-            src/lib.rs:5:80:}
-            src/lib.rs:12:139:    fn it_works() {
-            src/lib.rs:13:159:        let result = add(2, 2);
-            src/lib.rs:14:191:        assert_eq!(result, 4);
-            src/lib.rs:15:222:    }
+            src/helpers.rs:0:pub fn helper() {}
+            src/stop.rs:0:fn stop_it() {}
+            src/lib.rs:14:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:63:    left + right
+            src/lib.rs:80:}
+            src/lib.rs:139:    fn it_works() {
+            src/lib.rs:159:        let result = add(2, 2);
+            src/lib.rs:191:        assert_eq!(result, 4);
+            src/lib.rs:222:    }
         "#,
     );
 }
@@ -1286,15 +1310,15 @@ fn test_byte_offset_short_option() {
         "rust_project_byte_offset",
         r#"
             $ tree-sitter-grep -q '(function_item) @function_item' -l rust -b
-            src/helpers.rs:1:0:pub fn helper() {}
-            src/stop.rs:1:0:fn stop_it() {}
-            src/lib.rs:3:14:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:63:    left + right
-            src/lib.rs:5:80:}
-            src/lib.rs:12:139:    fn it_works() {
-            src/lib.rs:13:159:        let result = add(2, 2);
-            src/lib.rs:14:191:        assert_eq!(result, 4);
-            src/lib.rs:15:222:    }
+            src/helpers.rs:0:pub fn helper() {}
+            src/stop.rs:0:fn stop_it() {}
+            src/lib.rs:14:pub fn add(left: usize, right: usize) -> usize {
+            src/lib.rs:63:    left + right
+            src/lib.rs:80:}
+            src/lib.rs:139:    fn it_works() {
+            src/lib.rs:159:        let result = add(2, 2);
+            src/lib.rs:191:        assert_eq!(result, 4);
+            src/lib.rs:222:    }
         "#,
     );
 }
@@ -1319,8 +1343,8 @@ fn test_byte_offset_only_matching() {
         "rust_project_byte_offset",
         r#"
             $ tree-sitter-grep -q '(parameter) @c' -l rust --byte-offset --only-matching
-            src/lib.rs:3:25:left: usize
-            src/lib.rs:3:38:right: usize
+            src/lib.rs:25:left: usize
+            src/lib.rs:38:right: usize
         "#,
     );
 }

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -101,13 +101,13 @@ fn test_specify_single_file() {
         "rust_project",
         r#"
             $ tree-sitter-grep --query '(function_item) @function_item' --language rust src/lib.rs
-            src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
-            src/lib.rs:4:    left + right
-            src/lib.rs:5:}
-            src/lib.rs:12:    fn it_works() {
-            src/lib.rs:13:        let result = add(2, 2);
-            src/lib.rs:14:        assert_eq!(result, 4);
-            src/lib.rs:15:    }
+            3:pub fn add(left: usize, right: usize) -> usize {
+            4:    left + right
+            5:}
+            12:    fn it_works() {
+            13:        let result = add(2, 2);
+            14:        assert_eq!(result, 4);
+            15:    }
         "#,
     );
 }
@@ -117,7 +117,7 @@ fn test_specify_single_file_preserves_leading_dot_slash() {
     assert_sorted_output(
         "rust_project",
         r#"
-            $ tree-sitter-grep --query '(function_item) @function_item' --language rust ./src/lib.rs
+            $ tree-sitter-grep --query '(function_item) @function_item' --language rust --with-filename ./src/lib.rs
             ./src/lib.rs:3:pub fn add(left: usize, right: usize) -> usize {
             ./src/lib.rs:4:    left + right
             ./src/lib.rs:5:}
@@ -317,7 +317,7 @@ fn test_unknown_option() {
 
               tip: a similar argument exists: '--query'
 
-            Usage: tree-sitter-grep <--query-file <PATH_TO_QUERY_FILE>|--query <QUERY_TEXT>|--filter <PATH_TO_FILTER_PLUGIN_DYNAMIC_LIBRARY>> <PATHS|--query-file <PATH_TO_QUERY_FILE>|--query <QUERY_TEXT>|--capture <CAPTURE_NAME>|--language <LANGUAGE>|--filter <PATH_TO_FILTER_PLUGIN_DYNAMIC_LIBRARY>|--filter-arg <FILTER_ARG>|--vimgrep|--after-context <NUM>|--before-context <NUM>|--context <NUM>|--only-matching|--byte-offset|--colors <COLORS>|--color <WHEN>|--pretty|--heading|--no-heading>
+            Usage: tree-sitter-grep <--query-file <PATH_TO_QUERY_FILE>|--query <QUERY_TEXT>|--filter <PATH_TO_FILTER_PLUGIN_DYNAMIC_LIBRARY>> <PATHS|--query-file <PATH_TO_QUERY_FILE>|--query <QUERY_TEXT>|--capture <CAPTURE_NAME>|--language <LANGUAGE>|--filter <PATH_TO_FILTER_PLUGIN_DYNAMIC_LIBRARY>|--filter-arg <FILTER_ARG>|--vimgrep|--after-context <NUM>|--before-context <NUM>|--context <NUM>|--only-matching|--byte-offset|--colors <COLORS>|--color <WHEN>|--pretty|--heading|--no-heading|--with-filename|--no-filename>
 
             For more information, try '--help'.
         "#,
@@ -568,6 +568,24 @@ fn test_help_option() {
 
                       This overrides the --heading flag.
 
+              -H, --with-filename
+                      Display the file path for matches.
+
+                      This is the default when more than one file is searched. If --heading is enabled (the
+                      default when printing to a terminal), the file path will be shown above clusters of
+                      matches from each file; otherwise, the file name will be shown as a prefix for each
+                      matched line.
+
+                      This flag overrides --no-filename.
+
+              -I, --no-filename
+                      Never print the file path with the matched lines.
+
+                      This is the default when tree-sitter-grep is explicitly instructed to search one file or
+                      stdin.
+
+                      This flag overrides --with-filename.
+
               -h, --help
                       Print help (see a summary with '-h')
         "#,
@@ -625,6 +643,10 @@ fn test_help_short_option() {
                       printing the file path as a prefix for each matched line
                   --no-heading
                       Don't group matches by each file
+              -H, --with-filename
+                      Display the file path for matches
+              -I, --no-filename
+                      Never print the file path with the matched lines
               -h, --help
                       Print help (see more with '--help')
         "#,

--- a/tests/shared.rs
+++ b/tests/shared.rs
@@ -4,6 +4,7 @@ use std::{borrow::Cow, env, path::PathBuf, process::Command};
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use regex::Captures;
+use text_diff::print_diff;
 
 #[macro_export]
 macro_rules! regex {
@@ -193,6 +194,9 @@ pub fn assert_non_match_output(fixture_dir_name: &str, command_and_output: &str)
         .success()
         .stdout(predicate::function(|stdout: &str| {
             let stdout = massage_error_output(stdout);
+            if stdout != output {
+                print_diff(&stdout, &output, " ");
+            }
             stdout == output
         }));
 }


### PR DESCRIPTION
In this PR:
- mimic `ripgrep`'s heading/filename/line/column formatting (at least much more closely), eg showing a per-file "heading" and colors by default when outputting to a terminal

To test:
Now when running in a terminal by default you should see `ripgrep`-style output formatting (but with a different default set of colors)
If you eg redirect the output by doing `| cat -`, you should see different formatting that is more like our existing formatting but without showing line numbers (by default)
You should be able to use the newly exposed command-line arguments to modify those behaviors, eg use `--pretty` when redirecting the output to still get color/headings etc, use `--line-number` when redirecting the output to still get line numbers