### PR TITLE
Crate-level API changes for tree-sitter-lint

### DIFF
--- a/examples/print_match_text.rs
+++ b/examples/print_match_text.rs
@@ -3,10 +3,10 @@ use tree_sitter_grep::{run_with_callback, Args};
 
 fn main() {
     let args = Args::parse_from(["tree_sitter_grep", "-q", "(function_item) @f"]);
-    run_with_callback(args, |node, file_contents, path| {
+    run_with_callback(args, |capture_info, file_contents, path| {
         println!(
             "Found match in {path:?}: {}",
-            std::str::from_utf8(&file_contents[node.byte_range()]).unwrap(),
+            std::str::from_utf8(&file_contents[capture_info.node.byte_range()]).unwrap(),
         );
     })
     .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,9 +283,14 @@ pub fn run_print(args: Args) -> Result<RunStatus, Error> {
     )
 }
 
+pub struct CaptureInfo<'node> {
+    pub node: Node<'node>,
+    pub pattern_index: usize,
+}
+
 pub fn run_with_callback(
     args: Args,
-    callback: impl Fn(Node, &[u8], &Path) + Sync,
+    callback: impl Fn(CaptureInfo, &[u8], &Path) + Sync,
 ) -> Result<RunStatus, Error> {
     run_for_context(
         args,
@@ -300,8 +305,8 @@ pub fn run_with_callback(
                 .search_path_callback::<_, io::Error>(
                     query_context,
                     path,
-                    |node: Node, file_contents: &[u8], path: &Path| {
-                        callback(node, file_contents, path);
+                    |capture_info: CaptureInfo, file_contents: &[u8], path: &Path| {
+                        callback(capture_info, file_contents, path);
                         matched.store(true, Ordering::SeqCst);
                     },
                 )

--- a/src/searcher/mod.rs
+++ b/src/searcher/mod.rs
@@ -366,17 +366,12 @@ impl Searcher {
         let filter = &query_context.filter;
         query_cursor
             .captures(query, tree.root_node(), slice)
-            .filter_map(|(match_, found_capture_index)| {
-                let found_capture_index = found_capture_index as u32;
-                if found_capture_index != capture_index {
+            .filter_map(|(match_, index_into_query_match_captures)| {
+                let this_capture = &match_.captures[index_into_query_match_captures];
+                if this_capture.index != capture_index {
                     return None;
                 }
-                let mut nodes_for_this_capture = match_.nodes_for_capture_index(capture_index);
-                let single_captured_node = nodes_for_this_capture.next().unwrap();
-                assert!(
-                    nodes_for_this_capture.next().is_none(),
-                    "I guess .captures() always wraps up the single capture like this?"
-                );
+                let single_captured_node = this_capture.node;
                 match filter.as_ref() {
                     None => Some(CaptureInfo {
                         node: single_captured_node,


### PR DESCRIPTION
In this PR:
- some tweaks to the crate-level API from `run-context` that accommodate the `tree-sitter-lint` use case

(since the base branch is not "ready to merge", transitively neither is this really, though I suppose it could get merged down into the base branch?)

To test:
Per the updated example, the crate-level API now gives you visibility of the query "pattern index" that matched in addition to the `tree_sitter::Node` that matched

Based on `run-context`