### PR TITLE
Use upstream tree-sitter-rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ tree-sitter-objc = "1.1.0"
 tree-sitter-python = "0.20.2"
 tree-sitter-query = "0.1.0"
 tree-sitter-ruby = "0.20.0"
-tree-sitter-rust = { package = "tree_sitter_grep_tree-sitter-rust", git = "https://github.com/helixbass/tree-sitter-rust", rev = "781a8d9", version = "0.20.3-dev.0" }
+tree-sitter-rust = "0.20.3"
 tree-sitter-swift = "0.3.6"
 tree-sitter-toml = "0.20.0"
 tree-sitter-typescript = "0.20.2"

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -577,6 +577,7 @@ fn test_filter_argument_no_filter() {
 }
 
 #[test]
+#[ignore = "See https://github.com/helixbass/tree-sitter-grep/issues/70"]
 fn test_macro_contents() {
     assert_sorted_output(
         "match_inside_macro",


### PR DESCRIPTION
Disables `test_macro_contents` that relied on the custom fork of tree-sitter-rust.

Fixes https://github.com/helixbass/tree-sitter-grep/pull/70